### PR TITLE
Reformatted version of 0.9.2

### DIFF
--- a/Topology.dic
+++ b/Topology.dic
@@ -1,7 +1,7 @@
 #\#CIF_2.0
 ################################################################################
 #                                                                              #
-#          Topology CIF dictionary                                             #
+#       Topology CIF dictionary                                                #
 #                                                                              #
 ################################################################################
 
@@ -10,15 +10,13 @@ data_TOPOLOGY_CIF
     _dictionary.title             TOPOLOGY_CIF
     _dictionary.class             Instance
     _dictionary.version           0.9.2
-    _dictionary.date              2021-06-30
-    _dictionary.uri
-        https://github.com/COMCIFS/TopoCif/Topology.dic
+    _dictionary.date              2021-05-04
     _dictionary.ddl_conformance   3.13.1
-    _dictionary.namespace         Topo
     _description.text
 ;
     The Topology CIF dictionary provides datanames for describing crystal
-    structure   topology.
+      structure topology.  This is a DRAFT version and datanames in this
+      dictionary should not be used until final approval by COMCIFS.
 ;
 
 save_TOPOLOGY
@@ -28,7 +26,7 @@ save_TOPOLOGY
     _definition.class             Head
     _description.text
 ;
-    This category is the parent of all categories in the dictionary
+    This category is the parent of all categories in the dictionary.
 ;
     _name.category_id             TOPOLOGY_CIF
     _name.object_id               TOPOLOGY
@@ -49,7 +47,7 @@ save_TOPOL
     The TOPOL category covers data on connectivity
     between atoms and structural groups and the
     related structural properties as calculated from
-    the ATOM, CELL and SYMMETRY data.
+    the ATOM, CELL and SPACE_GROUP data.
 ;
     _name.category_id             TOPOLOGY
     _name.object_id               TOPOL
@@ -79,8 +77,8 @@ save_TOPOL
          C1 C 8 0.12500 0.12500 0.12500 1.0000
 
          loop_
-         _topol_repres_node.label
-         _topol_repres_node.atom_label
+         _topol_node.label
+         _topol_node.atom_label
          C1 C1
 
          loop_
@@ -96,13 +94,13 @@ save_TOPOL
          _topol_link.multiplicity
          C1 C1 1 [0 0 0] 13 [0 0 0] 1.5446 22.04 v 16
 
-         _topol_repres.overall_topology_RCSR dia
+         _topol_net.overall_topology_RCSR dia
 ;
 ;
-         Connectivity of the diamond crystal structure.
+         Example 1 - Connectivity of the diamond crystal structure.
          All atoms coincide with the nodes and all bonds coincide
          with the edges, so the atomic network coincides with the
-         underlying net.
+         underlying net. Thus, no special TOPOL_NET section is needed.
 ;
 ;
          loop_
@@ -128,13 +126,13 @@ save_TOPOL
          Ca1 Ca 6 0.00000 0.00000 0.00000 1.0000
 
          loop_
-         _topol_repres_node.label
-         _topol_repres_node.chemical_formula_sum
-         _topol_repres_node.fract_x
-         _topol_repres_node.fract_y
-         _topol_repres_node.fract_z
-         ZA1 Ca 0.00000 0.00000 0.25000
-         ZB1 CO3 0.00000 0.00000 0.00000
+         _topol_node.label
+         _topol_node.chemical_formula_sum
+         _topol_node.fract_x
+         _topol_node.fract_y
+         _topol_node.fract_z
+         ZA1 CO3 0.00000 0.00000 0.25000
+         ZB1 Ca 0.00000 0.00000 0.00000
 
          loop_
          _topol_link.node_label_1
@@ -148,14 +146,15 @@ save_TOPOL
          _topol_link.multiplicity
          ZA1 ZB1 1 [0 0 0] 20 [-1 -1 0] 3.2122 v 36
 
-         _topol_repres.overall_topology_RCSR pcu-b
+         _topol_net.overall_topology_RCSR pcu-b
 ;
 ;
-         Connectivity of an underlying net of the calcite
+         Example 2 - Connectivity of an underlying net of the calcite
          (CaCO3) crystal structure. The nodes of the underlying
          net correspond to Ca atoms and carbonate (CO3) groups.
          The underlying net has the NaCl (pcu-b in the RCSR
-         nomenclature) topology.
+         nomenclature) topology. Only the underlying net topology
+         is described, thus, no special TOPOL_NET section is needed.
 ;
 ;
          loop_
@@ -180,8 +179,8 @@ save_TOPOL
          Cu1 Cu 4 0.00000 0.00000 0.00000 1.0000
 
          loop_
-         _topol_repres_node.label
-         _topol_repres_node.atom_label
+         _topol_node.label
+         _topol_node.atom_label
          Node1 O1
 
          loop_
@@ -197,36 +196,131 @@ save_TOPOL
          1 Node1 Node1 1 [0 0 0] 13 [0 0 0] v 4
 
          loop_
-         _topol_repres_edge.id
-         _topol_repres_edge.chemical_formula_sum
+         _topol_edge.id
+         _topol_edge.chemical_formula_sum
          1 Cu
 
-         _topol_repres.overall_topology_RCSR dia
+         _topol_net.overall_topology_RCSR dia
 ;
 ;
-         Connectivity of an underlying net of the cuprite (Cu2O)
+         Example 3 - Connectivity of an underlying net of the cuprite (Cu2O)
          crystal structure. Oxygen atoms coincide with the nodes,
          while copper atoms represent the edges. There are two
-         interpenetrating networks of the diamond topology.
+         interpenetrating networks of the diamond topology. Only the underlying
+         net topology is described, thus, no special TOPOL_NET section is
+         needed.
 ;
-
-save_
-
-save_topol.repres_occurrence_total
-
-    _definition.id                '_topol.repres_occurrence_total'
-    _definition.update            2018-02-13
-    _description.text
 ;
-    The total number of occurrences in literature and databases of the
-    underlying net topology at the time the data file was prepared.
+         loop_
+         _space_group_symop.id
+         _space_group_symop.operation_xyz
+         1 x,y,z
+         2 -x,-y,z
+         3 x,-y,-z
+         # Symmetry elements elided
+         24 -z,y,-x
+
+         loop_
+         _atom_site.label
+         _atom_site.type_symbol
+         _atom_site.site_symmetry_multiplicity
+         _atom_site.fract_x
+         _atom_site.fract_y
+         _atom_site.fract_z
+         _atom_site.occupancy
+         Li1 Li 1 0.00000 0.00000 0.00000 1.0000
+         C1 C 4 0.31850 0.31850 0.31850 1.0000
+         O1 O 4 0.19920 0.19920 0.19920 1.0000
+         Co1 Co 1 0.50000 0.50000 0.50000 1.0000
+
+         loop_
+         _topol_net_id
+         _topol_net.special_details
+         _topol_net.overall_topology_TOPOS
+         Net_1 'Atomic net' 'Unknown'
+         Net_2 'Underlying net with carbonyl ligands as nodes' '2,4T3'
+
+         loop_
+         _topol_node.label
+         _topol_node.net_id
+         _topol_node.chemical_formula_sum
+         _topol_node.atom_label
+         _topol_node.fract_x
+         _topol_node.fract_y
+         _topol_node.fract_z
+         Li1 Net_1 . Li1 . . .
+         C1 Net_1 . C1 . . .
+         O1 Net_1 . O1 . . .
+         Co1 Net_1 . Co1 . . .
+         ZA1 Net_2 Li Li1 . . .
+         ZB1 Net_2 CO . 0.25036 0.25036 0.25036
+         ZC1 Net_2 Co . 0.50000 0.50000 0.50000
+
+         loop_
+         _topol_link.node_label_1
+         _topol_link.node_label_2
+         _topol_link.distance
+         _topol_link.site_symmetry_symop_1
+         _topol_link.site_symmetry_translation_1
+         _topol_link.site_symmetry_symop_2
+         _topol_link.site_symmetry_translation_2
+         _topol_link.type
+         _topol_link.multiplicity
+         Li1 O1 1.9121 1 [0 0 0] 3 [0 0 0] v 4
+         C1 O1 1.1452 1 [0 0 0] 1 [0 0 0] v 4
+         C1 Co1 1.7422 1 [0 0 0] 1 [0 0 0] v 4
+         ZA1 ZB1 2.4032 1 [0 0 0] 3 [0 0 0] v 4
+         ZB1 ZC1 2.3963 1 [0 0 0] 1 [0 0 0] v 4
 ;
-    _name.category_id             topol
-    _name.object_id               repres_occurrence_total
-    _type.purpose                 Number
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Integer
+;
+         Example 4 - Connectivity of atomic and underlying nets for
+         an interpenetrating array of two LiCo(CO)4 networks. The atomic
+         net consists of Li, C, O, and Co atoms, while the underlying
+         net is built from three kinds of nodes: Li and Co atoms and
+         carbonyl (CO) ligand; the nodes are labeled as ZA1, ZC1, and
+         ZB1, respectively. The _topol_node_* items include references
+         to atom labels for the atoms and coordinates for the nodes.
+         Some fields, which values are not required or should be taken
+         from the ATOM_SITE block, are specified with the '.' symbol.
+         Two possible variants are shown: the coordinates of ZA1 are
+         specified by a reference to Li1 atom, while the coordinates of
+         ZC1 are specified explicitly. Both atomic and underlying nets
+         are described in the TOPOL_NET section.
+;
+;
+         loop_
+         _topol_net_id
+         _topol_net.special_details
+         _topol_net.overall_topology_TOPOS
+         _topol_net.occurrence_total
+         Net_1 'Occurrence data are taken from topcryst.com' dia-a-a 5
+
+         loop_
+         _citation_id
+         _citation_database_id_CSD
+         1 MUMYIC
+         2 MUNDAA
+         3 MUMYUO
+         4 MUMYEY
+         5 MUMYAU
+
+         loop_
+         _topol_occurrence.id
+         _topol_occurrence.net_id
+         _topol_occurrence.citation_id
+         1 Net_1 1
+         2 Net_1 2
+         3 Net_1 3
+         4 Net_1 4
+         5 Net_1 5
+;
+;
+         Example 5 - Description of the occurrence of a particular topology
+         specified in the TOPOL_NET section. Here all occurrences refer to
+         structural determinations from the CSD. The total occurrence is
+         specified in _topol_net.occurrence_total; actually, it includes all
+         crystal structures with this topology that are currently known.
+;
 
 save_
 
@@ -236,7 +330,7 @@ save_topol.special_details
     _definition.update            2018-01-30
     _description.text
 ;
-    The description of topological information not covered by the
+    A description of topological information not covered by the
     existing data names in the topology categories.
 ;
     _name.category_id             topol
@@ -245,6 +339,115 @@ save_topol.special_details
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Text
+
+save_
+
+save_TOPOL_EDGE
+
+    _definition.id                TOPOL_EDGE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2018-01-30
+    _description.text
+;
+    The TOPOL_EDGE category describes the chemical composition of
+    the edges of the underlying net.
+;
+    _name.category_id             TOPOLOGY
+    _name.object_id               TOPOL_EDGE
+    _category_key.name            '_topol_edge.id'
+
+save_
+
+save_topol_edge.chemical_formula_iupac
+
+    _definition.id                '_topol_edge.chemical_formula_iupac'
+    _definition.update            2018-01-30
+    _description.text
+;
+    Formula of the residue or ion which corresponds to the edge,
+    expressed as per the description for _chemical_formula_iupac.
+;
+    _name.category_id             topol_edge
+    _name.object_id               chemical_formula_iupac
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_topol_edge.chemical_formula_moiety
+
+    _definition.id                '_topol_edge.chemical_formula_moiety'
+    _definition.update            2018-01-30
+    _description.text
+;
+    Formula of the residue or ion which corresponds to the edge.
+    The formula is written in accordance with the rules of the
+    _chemical_formula.moiety tag.
+;
+    _name.category_id             topol_edge
+    _name.object_id               chemical_formula_moiety
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_topol_edge.chemical_formula_sum
+
+    _definition.id                '_topol_edge.chemical_formula_sum'
+    _definition.update            2018-01-30
+    _description.text
+;
+    Formula of the residue or ion which corresponds to the edge.
+    The formula is written in accordance with the rules of  the
+    _chemical_formula.sum tag.
+;
+    _name.category_id             topol_edge
+    _name.object_id               chemical_formula_sum
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_topol_edge.id
+
+    _definition.id                '_topol_edge.id'
+    _definition.update            2018-01-30
+    _description.text
+;
+    The label of the edge. These must  match labels
+    specified as _topol_link.id in the TOPOL_LINK list.
+;
+    _name.category_id             topol_edge
+    _name.object_id               id
+    _name.linked_item_id          '_topol_link.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_TOPOL_ENTANGL
+
+    _definition.id                TOPOL_ENTANGL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2018-01-30
+    _description.text
+;
+    The TOPOL_ENTANGL category describes entanglements in the
+    underlying net.  This category is a placeholder for future development
+    of descriptions of entanglement.
+;
+    _name.category_id             TOPOLOGY
+    _name.object_id               TOPOL_ENTANGL
 
 save_
 
@@ -261,23 +464,26 @@ save_TOPOL_LINK
     symmetry-labeled quotient graph, from which the whole
     periodic net describing the overall topology of the crystal
     structure can be restored. The definition of
-    symmetry-labeled quotient graph was given by Klein,
-    H.-J. "Systematic generation of models for crystal
-    structures" Math. Modelling Scientific Computing 6 (1996)
-    325-330 and examples of weights and colors for the
-    graph edges and vertices are provided by Blatov, V.A. "A
-    method for hierarchical comparative analysis of crystal
-    structures." (2006) Acta Cryst. A62, 356-364.  The
+    symmetry-labeled quotient graph was given by Klein (1996)
+    and examples of weights and colors for the graph edges and
+    vertices are provided by Blatov (2006). The
     connections described in TOPOL_LINK may correspond to any
     vectors in the structure, not just bonds or contacts. The
-    nodes that are linked are listed in TOPOL_REPRES_NODE. In
+    nodes that are linked are listed in TOPOL_NODE. In
     order to properly describe the connectivity,
-    _topol_link.node_label_1
-    _topol_link.node_label_2,_topol_link.site_symmetry_symop_1,
-    _topol_link.site_symmetry_translation_1,_topol_link.site_symmetry_symop_2,
-    and_topol_link.site_symmetry_translation_2 must be given
+    _topol_link.node_label_1,
+    _topol_link.node_label_2,
+    _topol_link.site_symmetry_symop_1,
+    _topol_link.site_symmetry_translation_1,
+    _topol_link.site_symmetry_symop_2,
+    and _topol_link.site_symmetry_translation_2 must be given
     for each link, which is identified by _topol_link.id. Other
     items in this category are optional.
+
+    References: Klein, H.-J. (1996). Systematic generation of models
+    for crystal structures. Math. Model. Sci. Comput. 6, 325-330;
+    Blatov, V. A. (2006). A method for hierarchical comparative
+    analysis of crystal structures. Acta Cryst. A62, 356-364.
 ;
     _name.category_id             TOPOLOGY
     _name.object_id               TOPOL_LINK
@@ -345,12 +551,12 @@ save_topol_link.node_label_1
     _definition.update            2018-01-30
     _description.text
 ;
-    The labels of two nodes that form a link. These must match
-    nodes specified in topol_repres_node
+    The label of the first node associated with a link.
+    This must match a _topol_node.label value.
 ;
     _name.category_id             topol_link
     _name.object_id               node_label_1
-    _name.linked_item_id          '_topol_repres_node.label'
+    _name.linked_item_id          '_topol_node.label'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -364,12 +570,12 @@ save_topol_link.node_label_2
     _definition.update            2018-01-30
     _description.text
 ;
-    The labels of two nodes that form a link. These must match
-    nodes specified in topol_repres_node
+    The label of the second node associated with a link
+    This must match a _topol_node.label value.
 ;
     _name.category_id             topol_link
     _name.object_id               node_label_2
-    _name.linked_item_id          '_topol_repres_node.label'
+    _name.linked_item_id          '_topol_node.label'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -383,8 +589,8 @@ save_topol_link.order
     _definition.update            2018-05-16
     _description.text
 ;
-    The number of electron pairs participating in the bond described by
-    _topol_link.type.
+    The number of electron pairs participating in the bond
+    described by _topol_link.type.
 ;
     _name.category_id             topol_link
     _name.object_id               order
@@ -405,7 +611,7 @@ save_topol_link.site_symmetry_symop_1
     the node given by _topol_link.node_label_1 before addition of
     the translations in
     _topol_link.site_symmetry_translation_1. The value must match
-    a value of _space_group_symop.id. No normalisation of the
+    a value of _space_group_symop.id. No normalization of the
     resulting coordinates into the interval [0,1) is carried
     out. For example, (x+1/2, y+1/2,z) is not the same as (x-1/2,
     y+1/2,z) for these purposes.
@@ -430,7 +636,7 @@ save_topol_link.site_symmetry_symop_2
     the node given by _topol_link.node_label_2 before addition of
     the translations in
     _topol_link.site_symmetry_translation_2. The value must match
-    a value of _space_group_symop.id. No normalisation of the
+    a value of _space_group_symop.id. No normalization of the
     resulting coordinates into the interval [0,1) is carried
     out. For example, (x+1/2, y+1/2,z) is not the same as (x-1/2,
     y+1/2,z) for these purposes.
@@ -467,65 +673,6 @@ save_topol_link.site_symmetry_translation_1
     _type.container               Matrix
     _type.dimension               '[3]'
     _type.contents                Integer
-    _method.purpose               Evaluation
-    _method.expression
-;
-    with t as topol_link
-    _topol_link.site_symmetry_translation_1 = [t.site_symmetry_translation_1_x,
-                                               t.site_symmetry_translation_1_y,
-                                               t.site_symmetry_translation_1_z]
-;
-
-save_
-
-save_topol_link.site_symmetry_translation_1_x
-
-    _definition.id                '_topol_link.site_symmetry_translation_1_x'
-    _definition.update            2019-10-09
-    _description.text
-;
-    The x component of _topol_link.site_symmetry_translation_1.
-;
-    _name.category_id             topol_link
-    _name.object_id               site_symmetry_translation_1_x
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Integer
-
-save_
-
-save_topol_link.site_symmetry_translation_1_y
-
-    _definition.id                '_topol_link.site_symmetry_translation_1_y'
-    _definition.update            2019-10-09
-    _description.text
-;
-    The y component of _topol_link.site_symmetry_translation_1.
-;
-    _name.category_id             topol_link
-    _name.object_id               site_symmetry_translation_1_y
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Integer
-
-save_
-
-save_topol_link.site_symmetry_translation_1_z
-
-    _definition.id                '_topol_link.site_symmetry_translation_1_z'
-    _definition.update            2019-10-09
-    _description.text
-;
-    The z component of _topol_link.site_symmetry_translation_1.
-;
-    _name.category_id             topol_link
-    _name.object_id               site_symmetry_translation_1_z
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Integer
 
 save_
 
@@ -550,65 +697,6 @@ save_topol_link.site_symmetry_translation_2
     _type.source                  Derived
     _type.container               Matrix
     _type.dimension               '[3]'
-    _type.contents                Integer
-    _method.purpose               Evaluation
-    _method.expression
-;
-    with t as topol_link
-    _topol_link.site_symmetry_translation_2 = [t.site_symmetry_translation_2_x,
-                                               t.site_symmetry_translation_2_y,
-                                               t.site_symmetry_translation_2_z]
-;
-
-save_
-
-save_topol_link.site_symmetry_translation_2_x
-
-    _definition.id                '_topol_link.site_symmetry_translation_2_x'
-    _definition.update            2019-10-09
-    _description.text
-;
-    The x component of _topol_link.site_symmetry_translation_2.
-;
-    _name.category_id             topol_link
-    _name.object_id               site_symmetry_translation_2_x
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Integer
-
-save_
-
-save_topol_link.site_symmetry_translation_2_y
-
-    _definition.id                '_topol_link.site_symmetry_translation_2_y'
-    _definition.update            2019-10-09
-    _description.text
-;
-    The y component of _topol_link.site_symmetry_translation_2.
-;
-    _name.category_id             topol_link
-    _name.object_id               site_symmetry_translation_2_y
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
-    _type.contents                Integer
-
-save_
-
-save_topol_link.site_symmetry_translation_2_z
-
-    _definition.id                '_topol_link.site_symmetry_translation_2_z'
-    _definition.update            2019-10-09
-    _description.text
-;
-    The z component of _topol_link.site_symmetry_translation_2.
-;
-    _name.category_id             topol_link
-    _name.object_id               site_symmetry_translation_2_z
-    _type.purpose                 Number
-    _type.source                  Derived
-    _type.container               Single
     _type.contents                Integer
 
 save_
@@ -682,46 +770,49 @@ save_topol_link.voronoi_solidangle
     _type.source                  Derived
     _type.container               Single
     _type.contents                Real
-    _enumeration.range            1:50
+    _enumeration.range            0:50
     _units.code                   none
 
 save_
 
-save_TOPOL_REPRES
+save_TOPOL_NET
 
-    _definition.id                TOPOL_REPRES
+    _definition.id                TOPOL_NET
     _definition.scope             Category
-    _definition.class             Set
-    _definition.update            2018-01-30
+    _definition.class             Loop
+    _definition.update            2021-05-03
     _description.text
 ;
-    The TOPOL_REPRES category describes a particular crystal
-    structure representation, which corresponds to the periodic
-    (underlying) net topology specified in the TOPOL_LINK
-    category. The underlying net is the net of centroids of
-    structural units. The edges of this net represent the links
-    between the units.
+    The TOPOL_NET category describes an underlying net, its
+    topological properties and occurrence in other structures.
+
+    Reference: Delgado-Friedrichs, O., Foster, M. D., O'Keeffe, M.,
+          Proserpio, D. M., Treacy, M. M. J. & Yaghi, O. M. (2005).
+          J. Solid State Chem. 178, 2533-2554
 ;
     _name.category_id             TOPOLOGY
-    _name.object_id               TOPOL_REPRES
+    _name.object_id               TOPOL_NET
+    _category_key.name            '_topol_net.id'
 
 save_
 
-save_topol_repres.genus
+save_topol_net.genus
 
-    _definition.id                '_topol_repres.genus'
+    _definition.id                '_topol_net.genus'
     _definition.update            2018-02-06
     _description.text
 ;
-    The genus of the underlying net, defined as the cyclomatic number of its
-    own quotient graph: g = 1 + e - v, where e and v are the number of
-    edges and vertices in the quotient graph.  The quotient graph is a finite
-    graph that contains all of the information of the periodic net: the vertices
-    of the graph are the vertices of a translational repeat unit and the edges
-    are all the edges of the repeat unit. See O. Delgado_Friedrichs, M. O'Keeffe
-    J. Sol. State Chem. 178 (2005) 2480-2485
+    The genus of the underlying net, defined as the cyclomatic number of
+    its own quotient graph: g = 1 + e - v, where e and v are the number
+    of edges and vertices in the quotient graph.  The quotient graph is
+    a finite graph that contains all of the information of the periodic
+    net: the vertices of the graph are the vertices of a translational
+    repeat unit and the edges are all the edges of the repeat unit.
+
+    Reference: Delgado-Friedrichs, O. & O'Keeffe, M.
+    (2005). J. Solid State Chem. 178, 2480-2485.
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               genus
     _type.purpose                 Number
     _type.source                  Derived
@@ -730,15 +821,50 @@ save_topol_repres.genus
 
 save_
 
-save_topol_repres.overall_topology
+save_topol_net.id
 
-    _definition.id                '_topol_repres.overall_topology'
+    _definition.id                '_topol_net.id'
+    _definition.update            2021-05-05
+    _description.text
+;
+    The identifier of the underlying net.
+;
+    _name.category_id             topol_net
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_topol_net.occurrence_total
+
+    _definition.id                '_topol_net.occurrence_total'
+    _definition.update            2018-02-13
+    _description.text
+;
+    The total number of occurrences in literature and databases of the
+    underlying net topology at the time the data file was prepared.
+;
+    _name.category_id             topol_net
+    _name.object_id               occurrence_total
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+
+save_
+
+save_topol_net.overall_topology
+
+    _definition.id                '_topol_net.overall_topology'
     _definition.update            2018-01-30
     _description.text
 ;
     The overall topology symbol in an arbitrary form.
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               overall_topology
     _type.purpose                 Describe
     _type.source                  Assigned
@@ -748,16 +874,16 @@ save_topol_repres.overall_topology
 
 save_
 
-save_topol_repres.overall_topology_epinet
+save_topol_net.overall_topology_epinet
 
-    _definition.id                '_topol_repres.overall_topology_EPINET'
+    _definition.id                '_topol_net.overall_topology_EPINET'
     _definition.update            2018-01-30
     _description.text
 ;
     The identifier for the overall topology as listed
-    in the EPINET database at http://epinet.anu.edu.au
+    in the EPINET database at http://epinet.anu.edu.au.
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               overall_topology_EPINET
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -767,17 +893,19 @@ save_topol_repres.overall_topology_epinet
 
 save_
 
-save_topol_repres.overall_topology_rcsr
+save_topol_net.overall_topology_rcsr
 
-    _definition.id                '_topol_repres.overall_topology_RCSR'
+    _definition.id                '_topol_net.overall_topology_RCSR'
     _definition.update            2018-01-30
     _description.text
 ;
     The overall topology symbol according to the RCSR nomenclature described
-    by O'Keeffe, M., Peskov, M.A., Ramsden S. J., Yaghi O.M. (2008) Acc. Chem.
-    Res. 41, 1782-1789.
+    by O'Keeffe et al. (2008).
+
+    Reference: O'Keeffe, M., Peskov, M. A., Ramsden, S. J. & Yaghi, O. M.
+    (2008). Acc. Chem. Res. 41, 1782-1789.
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               overall_topology_RCSR
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -787,17 +915,19 @@ save_topol_repres.overall_topology_rcsr
 
 save_
 
-save_topol_repres.overall_topology_sp
+save_topol_net.overall_topology_sp
 
-    _definition.id                '_topol_repres.overall_topology_SP'
+    _definition.id                '_topol_net.overall_topology_SP'
     _definition.update            2018-01-30
     _description.text
 ;
     The overall topology symbol according to the nomenclature of
-    Fischer for sphere packings described in Koch, E., Fischer, W.
-    and Sowa, H. (2006) Acta Cryst. A62, 152-167.
+    Fischer for sphere packings described by Koch et al. (2006).
+
+    Reference: Koch, E., Fischer, W. & Sowa, H. (2006). Acta Cryst.
+    A62, 152-167.
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               overall_topology_SP
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -807,9 +937,9 @@ save_topol_repres.overall_topology_sp
 
 save_
 
-save_topol_repres.overall_topology_topos
+save_topol_net.overall_topology_topos
 
-    _definition.id                '_topol_repres.overall_topology_TOPOS'
+    _definition.id                '_topol_net.overall_topology_TOPOS'
     _definition.update            2018-02-06
     _description.text
 ;
@@ -819,11 +949,13 @@ save_topol_repres.overall_topology_topos
     C (chain), L (layer) or T (three-periodic) designating the dimensionality
     of the net; and n enumerates non-isomorphic nets with a given ND sequence.
     For finite (molecular) graphs the symbols NMK-n are used, where k is the
-    number of vertices (atoms) in the graph. See Aman, F., Asiri, A. M.,
-    Siddiqui, W. A., Arshad, M. N., Ashraf, A., Zakharov, N. S., Blatov, V. A.
-    (2014) CrystEngComm, 16, 1963-1970.
+    number of vertices (atoms) in the graph.
+
+    Reference: Aman, F., Asiri, A. M., Siddiqui, W. A., Arshad, M. N.,
+    Ashraf, A., Zakharov, N. S. & Blatov, V. A. (2014). Cryst. Eng. Comm,
+    16, 1963-1970.
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               overall_topology_TOPOS
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -833,27 +965,27 @@ save_topol_repres.overall_topology_topos
     _description_example.detail
 ;
     The third three-periodic trinodal net with two 3-coordinated and one
-        4-coordinated independent nodes
+    4-coordinated independent nodes
 ;
 
 save_
 
-save_topol_repres.period
+save_topol_net.period
 
-    _definition.id                '_topol_repres.period'
+    _definition.id                '_topol_net.period'
     _definition.update            2018-01-30
     _description.text
 ;
     Periodicity of the underlying net.  The allowed data values
     have the following meaning:
-        0         0-periodic (finite)
-        1         1-periodic (chain)
-        2         2-periodic (layer)
-        3         3-periodic (framework)
+       0     0-periodic (finite)
+       1     1-periodic (chain)
+       2     2-periodic (layer)
+       3     3-periodic (framework)
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               period
-    _type.purpose                 Number
+    _type.purpose                 State
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
@@ -861,9 +993,26 @@ save_topol_repres.period
 
 save_
 
-save_topol_repres.td10
+save_topol_net.special_details
 
-    _definition.id                '_topol_repres.td10'
+    _definition.id                '_topol_net.special_details'
+    _definition.update            2021-05-03
+    _description.text
+;
+    An arbitrary description of the net.
+;
+    _name.category_id             topol_net
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_topol_net.td10
+
+    _definition.id                '_topol_net.td10'
     _definition.update            2018-01-30
     _description.text
 ;
@@ -872,7 +1021,7 @@ save_topol_repres.td10
     atom. For structures with more than one kind of vertex in the asymmetric
     unit the value given is a weighted average over the vertices.
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               td10
     _type.purpose                 Number
     _type.source                  Assigned
@@ -881,17 +1030,17 @@ save_topol_repres.td10
 
 save_
 
-save_topol_repres.total_point_symbol
+save_topol_net.total_point_symbol
 
-    _definition.id                '_topol_repres.total_point_symbol'
+    _definition.id                '_topol_net.total_point_symbol'
     _definition.update            2018-01-30
     _description.text
 ;
-    The total point symbol of the underlying net.  This value summarizes all the
-    point symbols for the non-equivalent nodes with their stoichiometric
+    The total point symbol of the underlying net.  This value summarizes all
+    the point symbols for the non-equivalent nodes with their stoichiometric
     coefficients.
 ;
-    _name.category_id             topol_repres
+    _name.category_id             topol_net
     _name.object_id               total_point_symbol
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -906,145 +1055,38 @@ save_topol_repres.total_point_symbol
 
 save_
 
-save_TOPOL_REPRES_EDGE
+save_TOPOL_NODE
 
-    _definition.id                TOPOL_REPRES_EDGE
-    _definition.scope             Category
-    _definition.class             Loop
-    _definition.update            2018-01-30
-    _description.text
-;
-    The TOPOL_REPRES_EDGE category describes the chemical composition of
-    the edges of the underlying net.
-;
-    _name.category_id             TOPOLOGY
-    _name.object_id               TOPOL_REPRES_EDGE
-    _category_key.name            '_topol_repres_edge.id'
-
-save_
-
-save_topol_repres_edge.chemical_formula_iupac
-
-    _definition.id                '_topol_repres_edge.chemical_formula_iupac'
-    _definition.update            2018-01-30
-    _description.text
-;
-    Formula of the residue or ion, which corresponds to the edge
-         expressed in conformance with IUPAC rules.
-;
-    _name.category_id             topol_repres_edge
-    _name.object_id               chemical_formula_iupac
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_topol_repres_edge.chemical_formula_moiety
-
-    _definition.id                '_topol_repres_edge.chemical_formula_moiety'
-    _definition.update            2018-01-30
-    _description.text
-;
-    Formula of the residue or ion, which corresponds to the edge.
-         The formula is written in accordance with the rules of  the
-         _chemical_formula.moiety tag.
-;
-    _name.category_id             topol_repres_edge
-    _name.object_id               chemical_formula_moiety
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_topol_repres_edge.chemical_formula_sum
-
-    _definition.id                '_topol_repres_edge.chemical_formula_sum'
-    _definition.update            2018-01-30
-    _description.text
-;
-    Formula of the residue or ion, which corresponds to the edge.
-         The formula is written in accordance with the rules of  the
-         _chemical_formula.sum tag.
-;
-    _name.category_id             topol_repres_edge
-    _name.object_id               chemical_formula_sum
-    _type.purpose                 Encode
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-
-save_
-
-save_topol_repres_edge.id
-
-    _definition.id                '_topol_repres_edge.id'
-    _definition.update            2018-01-30
-    _description.text
-;
-    The label of the edge. These must  match labels
-         specified as _topol_link.id in the topol_link list.
-;
-    _name.category_id             topol_repres_edge
-    _name.object_id               id
-    _name.linked_item_id          '_topol_link.id'
-    _type.purpose                 Link
-    _type.source                  Related
-    _type.container               Single
-    _type.contents                Code
-
-save_
-
-save_TOPOL_REPRES_ENTANGL
-
-    _definition.id                TOPOL_REPRES_ENTANGL
-    _definition.scope             Category
-    _definition.class             Set
-    _definition.update            2018-01-30
-    _description.text
-;
-    The TOPOL_REPRES_ENTANGL category describes entanglements in the
-    underlying net.  This category is a placeholder for future development
-    of descriptions of entanglement.
-;
-    _name.category_id             TOPOLOGY
-    _name.object_id               TOPOL_REPRES_ENTANGL
-
-save_
-
-save_TOPOL_REPRES_NODE
-
-    _definition.id                TOPOL_REPRES_NODE
+    _definition.id                TOPOL_NODE
     _definition.scope             Category
     _definition.class             Loop
     _definition.update            2018-02-06
     _description.text
 ;
-    The TOPOL_REPRES_NODE category describes the chemical composition, structure
-         and topological properties of the nodes of the underlying net.
-         See Blatov V.A., O'Keeffe M., Proserpio D. M. CrystEngComm, 2010, 12,
-    44-48.      Nodes may be specified by reference to atom sites, or by
-    explicitly giving their      coordinates.
+    The TOPOL_NODE category describes the chemical composition,
+    structure and topological properties of the nodes of the underlying
+    net. Nodes may be specified by reference to atom sites, or by
+    explicitly giving their coordinates.
+
+    Reference: Blatov, V. A., O'Keeffe, M. & Proserpio, D. M. (2010).
+    Cryst. Eng. Comm. 12, 44-48.
 ;
     _name.category_id             TOPOLOGY
-    _name.object_id               TOPOL_REPRES_NODE
-    _category_key.name            '_topol_repres_node.label'
+    _name.object_id               TOPOL_NODE
+    _category_key.name            '_topol_node.label'
 
 save_
 
-save_topol_repres_node.atom_label
+save_topol_node.atom_label
 
-    _definition.id                '_topol_repres_node.atom_label'
-    _definition.update            2018-02-06
+    _definition.id                '_topol_node.atom_label'
     _description.text
 ;
-    The atom label corresponding to this node. Not all nodes have to coincide
-    with atom sites.
+    The atom label corresponding to this node. Not all nodes have
+    to coincide with atom sites. If a node does not correspond to an atom,
+    then this item, if present, should be represented by '.'.
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               atom_label
     _name.linked_item_id          '_atom_site.label'
     _type.purpose                 Link
@@ -1054,16 +1096,16 @@ save_topol_repres_node.atom_label
 
 save_
 
-save_topol_repres_node.chemical_formula_iupac
+save_topol_node.chemical_formula_iupac
 
-    _definition.id                '_topol_repres_node.chemical_formula_iupac'
+    _definition.id                '_topol_node.chemical_formula_iupac'
     _definition.update            2018-01-30
     _description.text
 ;
-    Formula of the residue or ion, which corresponds to the node
-    expressed in conformance with IUPAC rules.
+    Formula of the residue or ion which corresponds to the node,
+    expressed as per the description for _chemical_formula_iupac.
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               chemical_formula_iupac
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -1072,17 +1114,17 @@ save_topol_repres_node.chemical_formula_iupac
 
 save_
 
-save_topol_repres_node.chemical_formula_moiety
+save_topol_node.chemical_formula_moiety
 
-    _definition.id                '_topol_repres_node.chemical_formula_moiety'
+    _definition.id                '_topol_node.chemical_formula_moiety'
     _definition.update            2018-01-30
     _description.text
 ;
-    Formula of the residue or ion, which corresponds to the node.
-         The formula is written in accordance with the rules of  the
-         _chemical_formula.moiety tag.
+    Formula of the residue or ion which corresponds to the node.
+    The formula is written in accordance with the rules of  the
+    _chemical_formula.moiety tag.
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               chemical_formula_moiety
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -1091,17 +1133,17 @@ save_topol_repres_node.chemical_formula_moiety
 
 save_
 
-save_topol_repres_node.chemical_formula_sum
+save_topol_node.chemical_formula_sum
 
-    _definition.id                '_topol_repres_node.chemical_formula_sum'
+    _definition.id                '_topol_node.chemical_formula_sum'
     _definition.update            2018-01-30
     _description.text
 ;
-    Formula of the residue or ion, which corresponds to the node.
-         The formula is written in accordance with the rules of  the
-         _chemical_formula.sum tag.
+    Formula of the residue or ion which corresponds to the node.
+    The formula is written in accordance with the rules of  the
+    _chemical_formula.sum tag.
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               chemical_formula_sum
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -1110,19 +1152,19 @@ save_topol_repres_node.chemical_formula_sum
 
 save_
 
-save_topol_repres_node.coordination_sequence
+save_topol_node.coordination_sequence
 
-    _definition.id                '_topol_repres_node.coordination_sequence'
+    _definition.id                '_topol_node.coordination_sequence'
     _definition.update            2018-02-06
     _description.text
 ;
     The coordination sequence is a sequence of numbers counting the
-         atoms in the 1st, 2nd, 3rd etc. coordination shells of any given
-         node in the net. In other words, the kth entry in the list is the
-         number of vertices linked to the node by a path of exactly k
-         steps. It is usually listed up to k=10
+    atoms in the 1st, 2nd, 3rd etc. coordination shells of any given
+    node in the net. In other words, the kth entry in the list is the
+    number of vertices linked to the node by a path of exactly k
+    steps. It is usually listed up to k=10.
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               coordination_sequence
     _type.purpose                 Number
     _type.source                  Derived
@@ -1133,21 +1175,21 @@ save_topol_repres_node.coordination_sequence
 
 save_
 
-save_topol_repres_node.extended_point_symbol
+save_topol_node.extended_point_symbol
 
-    _definition.id                '_topol_repres_node.extended_point_symbol'
+    _definition.id                '_topol_node.extended_point_symbol'
     _definition.update            2018-02-06
     _description.text
 ;
     The extended point symbol of the node lists all shortest circuits
-         for each angle for each non-equivalent atom. A(b).B(c)... there
-         are b A-rings and c B-rings for all the N(N-1) circuits per node.
-         It is sorted so shortest rings came first For 4-coordinated
-         nodess only, the  angles are grouped in opposite pairs; ab,cd and
-         ac,bd and ad,bc (written in lexicographic order smallest numbers
-         first).
+    for each angle for each non-equivalent atom. A(b).B(c)... there
+    are b A-rings and c B-rings for all the N(N-1) circuits per node.
+    It is sorted so shortest rings come first. For 4-coordinated
+    nodes only, the  angles are grouped in opposite pairs; ab,cd and
+    ac,bd and ad,bc (written in lexicographic order smallest numbers
+    first).
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               extended_point_symbol
     _type.purpose                 Encode
     _type.source                  Derived
@@ -1168,46 +1210,82 @@ save_topol_repres_node.extended_point_symbol
 
 save_
 
-save_topol_repres_node.fract_x
+save_topol_node.fract_x
 
-    _definition.id                '_topol_repres_node.fract_x'
-    _name.category_id             topol_repres_node
+    _definition.id                '_topol_node.fract_x'
+    _description.text
+;
+    fractional x coordinate of this node.
+;
+    _name.category_id             topol_node
     _name.object_id               fract_x
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = atom_site[topol_node.atom_label].fract_x
+;
 
 save_
 
-save_topol_repres_node.fract_y
+save_topol_node.fract_y
 
-    _definition.id                '_topol_repres_node.fract_y'
-    _name.category_id             topol_repres_node
+    _definition.id                '_topol_node.fract_y'
+    _description.text
+;
+    fractional y coordinate of this node.
+;
+    _name.category_id             topol_node
     _name.object_id               fract_y
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = atom_site[topol_node.atom_label].fract_y
+;
 
 save_
 
-save_topol_repres_node.fract_z
+save_topol_node.fract_z
 
-    _definition.id                '_topol_repres_node.fract_z'
-    _name.category_id             topol_repres_node
+    _definition.id                '_topol_node.fract_z'
+    _description.text
+;
+    fractional z coordinate of this node.
+;
+    _name.category_id             topol_node
     _name.object_id               fract_z
-
-    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = atom_site[topol_node.atom_label].fract_z
+;
 
 save_
 
-save_topol_repres_node.label
+save_topol_node.label
 
-    _definition.id                '_topol_repres_node.label'
+    _definition.id                '_topol_node.label'
     _definition.update            2018-01-30
     _description.text
 ;
     The label of the node, which corresponds to a particular
-         node of the crystal structure representation.
+    node of the crystal structure representation.
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               label
     _type.purpose                 Key
     _type.source                  Assigned
@@ -1216,18 +1294,35 @@ save_topol_repres_node.label
 
 save_
 
-save_topol_repres_node.point_symbol
+save_topol_node.net_id
 
-    _definition.id                '_topol_repres_node.point_symbol'
+    _definition.id                '_topol_node.net_id'
+    _description.text
+;
+    The identifier of the net, to which this node belongs.
+;
+    _name.category_id             topol_node
+    _name.object_id               net_id
+    _name.linked_item_id          '_topol_net.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_topol_node.point_symbol
+
+    _definition.id                '_topol_node.point_symbol'
     _definition.update            2018-02-06
     _description.text
 ;
     The (short) point symbol of the node. This lists the number and size of
-         the shortest closed chains of connected nodes (circuits) starting from
-         any non-equivalent node in the net. For a N-coordinated node there are
-         N(N-1) circuits
+    the shortest closed chains of connected nodes (circuits) starting from
+    any non-equivalent node in the net. For an N-coordinated node there are
+    N(N-1) circuits
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               point_symbol
     _type.purpose                 Encode
     _type.source                  Derived
@@ -1244,19 +1339,22 @@ save_topol_repres_node.point_symbol
 
 save_
 
-save_topol_repres_node.structural_formula_inchi
+save_topol_node.structural_formula_inchi
 
-    _definition.id                '_topol_repres_node.structural_formula_InChI'
+    _definition.id                '_topol_node.structural_formula_InChI'
     _definition.update            2018-04-05
     _description.text
 ;
-    Formula of the residue or ion, which corresponds to the node.
+    Formula of the residue or ion which corresponds to the node.
     The formula is written in accordance with the rules for IUPAC
     international chemical identifiers (InChI) as described
-    by Heller et al. Journal of Cheminformatics (2015) 7:23 ,
+    by Heller et al. (2015).
+
+    Reference: Heller, S. R., McNaught, A., Pletnev, I. &
+    Tchekhovskoi, D. (2015). J. Cheminformat. 7:23,
     DOI:10.1186/s13321-015-0068-4.
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               structural_formula_inchi
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -1265,18 +1363,18 @@ save_topol_repres_node.structural_formula_inchi
 
 save_
 
-save_topol_repres_node.structural_formula_smiles
+save_topol_node.structural_formula_smiles
 
-    _definition.id                '_topol_repres_node.structural_formula_SMILES'
+    _definition.id                '_topol_node.structural_formula_SMILES'
     _definition.update            2018-04-05
     _description.text
 ;
-    Formula of the residue or ion, which corresponds to the node.
+    Formula of the residue or ion which corresponds to the node.
     The formula is written in SMILES notation for describing
     chemical structure as formalised by the OpenSMILES group
     (https://www.opensmiles.org).
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               structural_formula_smiles
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -1285,19 +1383,19 @@ save_topol_repres_node.structural_formula_smiles
 
 save_
 
-save_topol_repres_node.symmetry_multiplicity
+save_topol_node.symmetry_multiplicity
 
-    _definition.id                '_topol_repres_node.symmetry_multiplicity'
+    _definition.id                '_topol_node.symmetry_multiplicity'
     _definition.update            2018-02-23
     _description.text
 ;
     The number of different sites that are generated by the
-         application of the space-group symmetry to the coordinates
-         given for this site. It is equal to the multiplicity given
-         for this Wyckoff site in International Tables for Cryst.
-         Vol. A (2002).
+    application of the space-group symmetry to the coordinates
+    given for this site. It is equal to the multiplicity given
+    for this Wyckoff site in International Tables for Crystallography
+    Vol. A (2002).
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               symmetry_multiplicity
     _type.purpose                 Number
     _type.source                  Derived
@@ -1307,24 +1405,24 @@ save_topol_repres_node.symmetry_multiplicity
 
 save_
 
-save_topol_repres_node.vertex_symbol
+save_topol_node.vertex_symbol
 
-    _definition.id                '_topol_repres_node.vertex_symbol'
+    _definition.id                '_topol_node.vertex_symbol'
     _definition.update            2018-02-06
     _description.text
 ;
     The vertex symbol of a node provides similar information to the
-         extended point symbol, but only for rings, which are circuits
-         that contain no shortcuts, that is, are not the sum of  two
-         smaller circuits. There may be circuits that cannot be rings. If
-         there are no rings meeting at a particular angle of the node, the
-         symbol '*' is used instead of the A^a symbol. It is sorted so
-         shortest rings came first For 4-coordinated nodess only, the
-         angles are grouped in opposite pairs; ab,cd and ac,bd and ad,bc
-         (written in lexicographic order smallest numbers first). In the
-         ordering the symbol '*' is equivalent to zero.
+    extended point symbol, but only for rings, which are circuits
+    that contain no shortcuts, that is, are not the sum of  two
+    smaller circuits. There may be circuits that cannot be rings. If
+    there are no rings meeting at a particular angle of the node, the
+    symbol '*' is used instead of the A^a symbol. It is sorted so
+    shortest rings come first. For 4-coordinated nodes only, the
+    angles are grouped in opposite pairs; ab,cd and ac,bd and ad,bc
+    (written in lexicographic order smallest numbers first). In the
+    ordering the symbol '*' is equivalent to zero.
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               vertex_symbol
     _type.purpose                 Encode
     _type.source                  Derived
@@ -1341,16 +1439,16 @@ save_topol_repres_node.vertex_symbol
 
 save_
 
-save_topol_repres_node.wyckoff_symbol
+save_topol_node.wyckoff_symbol
 
-    _definition.id                '_topol_repres_node.Wyckoff_symbol'
+    _definition.id                '_topol_node.Wyckoff_symbol'
     _definition.update            2018-02-23
     _description.text
 ;
     The Wyckoff symbol (letter) as listed in the space-group section
-         of International Tables for Crystallography, Vol. A (1987).
+    of International Tables for Crystallography, Vol. A (1987).
 ;
-    _name.category_id             topol_repres_node
+    _name.category_id             topol_node
     _name.object_id               Wyckoff_symbol
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -1359,36 +1457,36 @@ save_topol_repres_node.wyckoff_symbol
 
 save_
 
-save_TOPOL_REPRES_OCCURRENCE
+save_TOPOL_OCCURRENCE
 
-    _definition.id                TOPOL_REPRES_OCCURRENCE
+    _definition.id                TOPOL_OCCURRENCE
     _definition.scope             Category
     _definition.class             Loop
     _definition.update            2018-01-30
     _description.text
 ;
-    The TOPOL_REPRES_OCCURRENCE category lists the appearances of the
+    The TOPOL_OCCURRENCE category lists the appearances of the
     underlying net topology in crystal structures.
 ;
     _name.category_id             TOPOLOGY
-    _name.object_id               TOPOL_REPRES_OCCURRENCE
-    _category_key.name            '_topol_repres_occurrence.id'
+    _name.object_id               TOPOL_OCCURRENCE
+    _category_key.name            '_topol_occurrence.id'
 
 save_
 
-save_topol_repres_occurrence.citation_id
+save_topol_occurrence.citation_id
 
-    _definition.id                '_topol_repres_occurrence.citation_id'
+    _definition.id                '_topol_occurrence.citation_id'
     _definition.update            2018-04-17
     _description.text
 ;
-    Reference to a publication, where a crystal  structure with the
-    underlying net topology  was characterized.  This item is a pointer
+    Reference to a publication, where a crystal structure with the
+    underlying net topology  was characterized. This item is a pointer
     to an item described in the core CITATION category. If a publication
     and database entry are not directly related, they should be listed
     in separate rows.
 ;
-    _name.category_id             topol_repres_occurrence
+    _name.category_id             topol_occurrence
     _name.object_id               citation_id
     _name.linked_item_id          '_citation.id'
     _type.purpose                 Link
@@ -1398,15 +1496,15 @@ save_topol_repres_occurrence.citation_id
 
 save_
 
-save_topol_repres_occurrence.id
+save_topol_occurrence.id
 
-    _definition.id                '_topol_repres_occurrence.id'
+    _definition.id                '_topol_occurrence.id'
     _definition.update            2018-02-13
     _description.text
 ;
-    A unique identifier for the literature or database reference
+    A unique identifier for the literature or database reference.
 ;
-    _name.category_id             topol_repres_occurrence
+    _name.category_id             topol_occurrence
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Assigned
@@ -1415,44 +1513,61 @@ save_topol_repres_occurrence.id
 
 save_
 
-save_TOPOL_REPRES_TILING
+save_topol_occurrence.net_id
 
-    _definition.id                TOPOL_REPRES_TILING
+    _definition.id                '_topol_occurrence.net_id'
+    _description.text
+;
+    The identifier of the net, which topology occurrence is described.
+;
+    _name.category_id             topol_occurrence
+    _name.object_id               net_id
+    _name.linked_item_id          '_topol_net.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_TOPOL_TILING
+
+    _definition.id                TOPOL_TILING
     _definition.scope             Category
     _definition.class             Set
     _definition.update            2018-02-06
     _description.text
 ;
-    The TOPOL_REPRES_TILING category describes the natural tiling
+    The TOPOL_TILING category describes the natural tiling
     corresponding to the underlying net.  A tiling is a
     partition of crystal space using generalised polyhedra, and a
     natural tiling is one for which tiles are the smallest possible
     that conserve the full symmetry of the net and for which the
     faces are all locally strong rings. This means that there is no
     single largest face (face with the largest number of vertices)
-    as such a face will be the some of the other smaller faces.
+    as such a face will be the sum of the other smaller faces.
 
     The tile signature contains the sizes of the tile faces and
     the number of faces of a given size in the tile.
 
-    See: Blatov V. A., Delgado-Friedrichs, O., O'Keeffe M.,
-    Proserpio D. M.   Acta Cryst. 2007, A63, 418-425
+    Reference: Blatov, V. A., Delgado-Friedrichs, O., O'Keeffe M. &
+    Proserpio D. M. (2007). Acta Cryst. A63, 418-425.
 ;
     _name.category_id             TOPOLOGY
-    _name.object_id               TOPOL_REPRES_TILING
+    _name.object_id               TOPOL_TILING
 
 save_
 
-save_topol_repres_tiling.dsize
+save_topol_tiling.dsize
 
-    _definition.id                '_topol_repres_tiling.Dsize'
+    _definition.id                '_topol_tiling.Dsize'
     _definition.update            2018-01-30
     _description.text
 ;
-    The number of distinct (not symmetry-related) chambers  in the
+    The number of distinct (not symmetry-related) chambers in the
     tiling.
 ;
-    _name.category_id             topol_repres_tiling
+    _name.category_id             topol_tiling
     _name.object_id               Dsize
     _type.purpose                 Number
     _type.source                  Derived
@@ -1461,16 +1576,16 @@ save_topol_repres_tiling.dsize
 
 save_
 
-save_topol_repres_tiling.dual
+save_topol_tiling.dual
 
-    _definition.id                '_topol_repres_tiling.dual'
+    _definition.id                '_topol_tiling.dual'
     _definition.update            2018-01-30
     _description.text
 ;
     The overall topology symbol of the dual net, which  corresponds
     to the net of the dual of the natural tiling.
 ;
-    _name.category_id             topol_repres_tiling
+    _name.category_id             topol_tiling
     _name.object_id               dual
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -1479,15 +1594,15 @@ save_topol_repres_tiling.dual
 
 save_
 
-save_topol_repres_tiling.edges
+save_topol_tiling.edges
 
-    _definition.id                '_topol_repres_tiling.edges'
+    _definition.id                '_topol_tiling.edges'
     _definition.update            2018-01-30
     _description.text
 ;
     Number of independent tile edges in the natural tiling.
 ;
-    _name.category_id             topol_repres_tiling
+    _name.category_id             topol_tiling
     _name.object_id               edges
     _type.purpose                 Number
     _type.source                  Recorded
@@ -1496,15 +1611,15 @@ save_topol_repres_tiling.edges
 
 save_
 
-save_topol_repres_tiling.faces
+save_topol_tiling.faces
 
-    _definition.id                '_topol_repres_tiling.faces'
+    _definition.id                '_topol_tiling.faces'
     _definition.update            2018-01-30
     _description.text
 ;
     Number of independent tile faces in the natural tiling.
 ;
-    _name.category_id             topol_repres_tiling
+    _name.category_id             topol_tiling
     _name.object_id               faces
     _type.purpose                 Number
     _type.source                  Assigned
@@ -1513,20 +1628,19 @@ save_topol_repres_tiling.faces
 
 save_
 
-save_topol_repres_tiling.signature
+save_topol_tiling.signature
 
-    _definition.id                '_topol_repres_tiling.signature'
+    _definition.id                '_topol_tiling.signature'
     _definition.update            2018-02-06
     _description.text
 ;
-    The tiling signature, written in the form \a[A^a^ . B^b^ ...]+\b[C^c^ .
-    D^d^ ...]+..., where square brackets envelop tile symbols, \a,\b,... are
-    stoichiometric coefficients, A, B, C, D, ... are sizes of tile faces,
-    a,b,c,d, ... are numbers of the faces of a given size in the tile.
-    The signature is written in a  lexicographic order, smallest numbers first:
-    5[6^4^]+[6^3^] = 56463 better than [6^3^]+5[6^4^] = 63564
+    The tiling signature, written in the form
+    \a[A^a^ . B^b^ ...]+\b[C^c^ . D^d^ ...]+...,
+    where square brackets envelop tile symbols, \a,\b,... are stoichiometric
+    coefficients, A, B, C, D, ... are sizes of tile faces, a,b,c,d, ... are
+    numbers of the faces of a given size in the tile.
 ;
-    _name.category_id             topol_repres_tiling
+    _name.category_id             topol_tiling
     _name.object_id               signature
     _type.purpose                 Encode
     _type.source                  Assigned
@@ -1541,15 +1655,15 @@ save_topol_repres_tiling.signature
 
 save_
 
-save_topol_repres_tiling.tiles
+save_topol_tiling.tiles
 
-    _definition.id                '_topol_repres_tiling.tiles'
+    _definition.id                '_topol_tiling.tiles'
     _definition.update            2018-01-30
     _description.text
 ;
     Number of independent tiles in the natural tiling.
 ;
-    _name.category_id             topol_repres_tiling
+    _name.category_id             topol_tiling
     _name.object_id               tiles
     _type.purpose                 Number
     _type.source                  Assigned
@@ -1558,15 +1672,15 @@ save_topol_repres_tiling.tiles
 
 save_
 
-save_topol_repres_tiling.vertices
+save_topol_tiling.vertices
 
-    _definition.id                '_topol_repres_tiling.vertices'
+    _definition.id                '_topol_tiling.vertices'
     _definition.update            2018-01-30
     _description.text
 ;
     Number of independent tile vertices in the natural tiling.
 ;
-    _name.category_id             topol_repres_tiling
+    _name.category_id             topol_tiling
     _name.object_id               vertices
     _type.purpose                 Number
     _type.source                  Assigned
@@ -1575,62 +1689,62 @@ save_topol_repres_tiling.vertices
 
 save_
 
-save_TOPOL_REPRES_TILING_FACES
+save_TOPOL_TILING_FACES
 
-    _definition.id                TOPOL_REPRES_TILING_FACES
+    _definition.id                TOPOL_TILING_FACES
     _definition.scope             Category
     _definition.class             Loop
     _definition.update            2018-02-13
     _description.text
 ;
-    The TOPOL_REPRES_TILING_FACES category tabulates the faces
+    The TOPOL_TILING_FACES category tabulates the faces
     belonging to each tile in the tiling.  Together with the
-    TOPOL_REPRES_TILING_TILES category it tabulates the information
-    contained in _topol_repres_tiling.signature. See the
-    TOPOL_REPRES_TILING category for further information.
+    TOPOL_TILING_TILES category it tabulates the information
+    contained in _topol_tiling.signature. See the
+    TOPOL_TILING category for further information.
 ;
     _name.category_id             TOPOLOGY
-    _name.object_id               TOPOL_REPRES_TILING_FACES
+    _name.object_id               TOPOL_TILING_FACES
 
     loop_
       _category_key.name
-         '_topol_repres_tiling_faces.tile_id'
-         '_topol_repres_tiling_faces.size'
+         '_topol_tiling_faces.tile_id'
+         '_topol_tiling_faces.size'
 
     _description_example.case
 ;
     loop_
-          _topol_repres_tiling_tile.id
-          _topol_repres_tiling_tile.count
-          a     3
-          b     1
-          c     1
+       _topol_tiling_tile.id
+       _topol_tiling_tile.count
+       a  3
+       b  1
+       c  1
 
-        loop_
-          _topol_repres_tiling_faces.tile_id
-          _topol_repres_tiling_faces.size
-          _topol_repres_tiling_faces.count
-          a    4   6
-          b    4   6
-          b    6   8
-          c    4   12
-          c    6   8
-          c    8   6
+     loop_
+       _topol_tiling_faces.tile_id
+       _topol_tiling_faces.size
+       _topol_tiling_faces.count
+       a 4   6
+       b 4   6
+       b 6   8
+       c 4   12
+       c 6   8
+       c 8   6
 ;
     _description_example.detail
         'Expanded description of 3[4^6^]+[4^6^.6^8^]+[4^12^.6^8^.8^6^] tiling'
 
 save_
 
-save_topol_repres_tiling_faces.count
+save_topol_tiling_faces.count
 
-    _definition.id                '_topol_repres_tiling_faces.count'
+    _definition.id                '_topol_tiling_faces.count'
     _definition.update            2018-02-13
     _description.text
 ;
-    The number of faces of this size in the tile
+    The number of faces of this size in the tile.
 ;
-    _name.category_id             topol_repres_tiling_faces
+    _name.category_id             topol_tiling_faces
     _name.object_id               count
     _type.purpose                 Number
     _type.source                  Assigned
@@ -1639,15 +1753,15 @@ save_topol_repres_tiling_faces.count
 
 save_
 
-save_topol_repres_tiling_faces.size
+save_topol_tiling_faces.size
 
-    _definition.id                '_topol_repres_tiling_faces.size'
+    _definition.id                '_topol_tiling_faces.size'
     _definition.update            2018-02-13
     _description.text
 ;
     The size of the tile face.
 ;
-    _name.category_id             topol_repres_tiling_faces
+    _name.category_id             topol_tiling_faces
     _name.object_id               size
     _type.purpose                 Number
     _type.source                  Assigned
@@ -1657,18 +1771,18 @@ save_topol_repres_tiling_faces.size
 
 save_
 
-save_topol_repres_tiling_faces.tile_id
+save_topol_tiling_faces.tile_id
 
-    _definition.id                '_topol_repres_tiling_faces.tile_id'
+    _definition.id                '_topol_tiling_faces.tile_id'
     _definition.update            2018-02-13
     _description.text
 ;
     The tile to which this face belongs. It must be one of the values provided
-    in _topol_repres_tiling_tile.id
+    in _topol_tiling_tile.id.
 ;
-    _name.category_id             topol_repres_tiling_faces
+    _name.category_id             topol_tiling_faces
     _name.object_id               tile_id
-    _name.linked_item_id          '_topol_repres_tiling_tile.id'
+    _name.linked_item_id          '_topol_tiling_tile.id'
     _type.purpose                 Link
     _type.source                  Related
     _type.container               Single
@@ -1676,35 +1790,35 @@ save_topol_repres_tiling_faces.tile_id
 
 save_
 
-save_TOPOL_REPRES_TILING_TILE
+save_TOPOL_TILING_TILE
 
-    _definition.id                TOPOL_REPRES_TILING_TILE
+    _definition.id                TOPOL_TILING_TILE
     _definition.scope             Category
     _definition.class             Loop
     _definition.update            2018-02-13
     _description.text
 ;
-    The TOPOL_REPRES_TILING_TILE category provides information on
+    The TOPOL_TILING_TILE category provides information on
     each of the tiles in the tiling. Together with the
-    TOPOL_REPRES_TILING_FACES category it tabulates the information
-    contained in _topol_repres_tiling.signature. See the
-    TOPOL_REPRES_TILING category for further information.
+    TOPOL_TILING_FACES category it tabulates the information
+    contained in _topol_tiling.signature. See the
+    TOPOL_TILING category for further information.
 ;
     _name.category_id             TOPOLOGY
-    _name.object_id               TOPOL_REPRES_TILING_TILE
-    _category_key.name            '_topol_repres_tiling_tile.id'
+    _name.object_id               TOPOL_TILING_TILE
+    _category_key.name            '_topol_tiling_tile.id'
 
 save_
 
-save_topol_repres_tiling_tile.count
+save_topol_tiling_tile.count
 
-    _definition.id                '_topol_repres_tiling_tile.count'
+    _definition.id                '_topol_tiling_tile.count'
     _definition.update            2018-02-13
     _description.text
 ;
     The number of this kind of tile in the tiling.
 ;
-    _name.category_id             topol_repres_tiling_tile
+    _name.category_id             topol_tiling_tile
     _name.object_id               count
     _type.purpose                 Number
     _type.source                  Assigned
@@ -1713,15 +1827,15 @@ save_topol_repres_tiling_tile.count
 
 save_
 
-save_topol_repres_tiling_tile.id
+save_topol_tiling_tile.id
 
-    _definition.id                '_topol_repres_tiling_tile.id'
+    _definition.id                '_topol_tiling_tile.id'
     _definition.update            2018-02-13
     _description.text
 ;
     An arbitrary, unique identifier for this tile type.
 ;
-    _name.category_id             topol_repres_tiling_tile
+    _name.category_id             topol_tiling_tile
     _name.object_id               id
     _type.purpose                 Key
     _type.source                  Assigned
@@ -1737,8 +1851,8 @@ save_
          0.3                      2018-02-23
 ;
        Changed topol_bond to topol_link using node labels instead of atom
-       labels. Added coordinates, multiplicity and Wyckoff symbol to
-       topol_repres_node. Added in type and linking information. (J Hester.)
+       labels. Added coordinates, multiplicity and Wyckoff symbol to topol_node.
+       Added in type and linking information. (J Hester.)
 ;
          0.4                      2018-02-27
 ;
@@ -1754,8 +1868,12 @@ save_
        Version for final approval after review. Removed most datanames from
        TOPOL_ENTANGL and subcategories.
 ;
-         0.9.1                    2019-10-09
+         0.9.1                    2019-07-17
 ;
-       Added individual components of the site_symmetry_translation data names
-       (J Hester)
+       Fixed a few typos. (B. McMahon)
+;
+         0.9.2                    2021-05-04
+;
+       Replaced TOPOL_REPRES category by TOPOL_NET; all TOPOL_REPRES categories
+       are        moved to TOPOL category; Examples 4 and 5 added
 ;

--- a/Topology.dic
+++ b/Topology.dic
@@ -985,7 +985,7 @@ save_topol_net.period
 ;
     _name.category_id             topol_net
     _name.object_id               period
-    _type.purpose                 State
+    _type.purpose                 Number
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer


### PR DESCRIPTION
The dictionary currently at dictionaries/TopologyCIF_0.9.2.dic reformatted, syntax corrected, outdated values updated, tabs removed.

Checked against original using julia_cif_tools/compare.jl, only one difference in one example due to whitespace.