### PR TITLE
Correct several data name typos in examples

### DIFF
--- a/Topology.dic
+++ b/Topology.dic
@@ -503,7 +503,7 @@ save_TOPOL
 ;
 ;
          loop_
-         _topol_net_id
+         _topol_net.id
          _topol_net.special_details
          _topol_net.overall_topology_RCSR
          _topol_net.occurrence_total

--- a/more_examples/MOF5-v2b.cif
+++ b/more_examples/MOF5-v2b.cif
@@ -267,7 +267,7 @@ _topol_link.net_id
 _topol_link.node_id_1
 _topol_link.node_id_2
 _topol_link.symop_id_2
-_topol_link.tanslation_2
+_topol_link.translation_2
 _topol_link.distance
 _topol_link.type
 _topol_link.multiplicity
@@ -285,7 +285,7 @@ loop_
 _topol_node.id
 _topol_node.net_id
 _topol_node.atom_label
-_topol_node.symop
+_topol_node.symop_id
 _topol_node.translation
 _topol_node.chemical_formula_sum
 1  1  H1   .  .  H

--- a/more_examples/MOF5-v2c.cif
+++ b/more_examples/MOF5-v2c.cif
@@ -267,7 +267,7 @@ _topol_link.net_id
 _topol_link.node_id_1
 _topol_link.node_id_2
 _topol_link.symop_id_2
-_topol_link.tanslation_2
+_topol_link.translation_2
 _topol_link.distance
 _topol_link.type
 _topol_link.multiplicity
@@ -300,7 +300,7 @@ _topol_node.chemical_formula_sum
 loop_
 _topol_atom.id
 _topol_atom.atom_label
-_topol_atom.elementSymbol
+_topol_atom.element_symbol
 _topol_atom.node_id
 _topol_atom.link_id
 _topol_atom.symop_id

--- a/more_examples/saymub-new.cif
+++ b/more_examples/saymub-new.cif
@@ -564,7 +564,7 @@ _topol_link.Voronoi_solidangle
 loop_						
 _topol_node.id						
 _topol_node.atom_label						
-_topol_node.symop						
+_topol_node.symop_id						
 _topol_node.translation						
 _topol_node.chemical_formula_sum						
 1	H1	1 [0 0 0]	H			


### PR DESCRIPTION
This PR fixes several minor typos in data names that appear in example files as well as the dictionary itself.