### PR TITLE
Homogenise dictionary version numbers to the SemVer 2.0.0 format

### DIFF
--- a/Topology.dic
+++ b/Topology.dic
@@ -2829,22 +2829,22 @@ save_
       _dictionary_audit.version
       _dictionary_audit.date
       _dictionary_audit.revision
-         0.3                      2018-02-23
+         0.3.0                    2018-02-23
 ;
        Changed topol_bond to topol_link using node labels instead of atom
        labels. Added coordinates, multiplicity and Wyckoff symbol to topol_node.
        Added in type and linking information. (J Hester.)
 ;
-         0.4                      2018-02-27
+         0.4.0                    2018-02-27
 ;
        Added long-form examples provided by V Blatov. Version for review.
 ;
-         0.5                      2018-04-05
+         0.5.0                    2018-04-05
 ;
        Added InChI, SMILES structural formulas and replaced symops with explicit
        symmetry operator ids and vector translations. Clarified bond types.
 ;
-         0.9                      2018-05-28
+         0.9.0                    2018-05-28
 ;
        Version for final approval after review. Removed most tags from
        TOPOL_ENTANGL and subcategories.


### PR DESCRIPTION
This PR changes the previously assigned version numbers to the SemVer 2.0.0 format [1] to satisfy additional GitHub Action check that would be introduced by merging a PR [2] in the dictionary_check_action repository.

The SemVer format is generally compatible with the DDL 'Version' data type, although, slightly stricter in its syntax. For example, it requires all 3 version components to always be present ("1.0.0" is OK, but "1.0" is not) and does not permit leading zeros ("3.0.5" is OK, but "3.0.05" is not). Although these type of requirements are not (yet) mandated by the DDL reference dictionary, they do help with keeping consistent version numbers.

[1] https://semver.org/spec/v2.0.0.html
[2] COMCIFS/dictionary_check_action#6