### PR TITLE
Redefine Wyckoff symbol as enumeration set

### DIFF
--- a/Topology.dic
+++ b/Topology.dic
@@ -10,7 +10,7 @@ data_TOPOLOGY_CIF
     _dictionary.title             TOPOLOGY_CIF
     _dictionary.class             Instance
     _dictionary.version           0.9.4
-    _dictionary.date              2021-09-17
+    _dictionary.date              2021-09-24
     _dictionary.ddl_conformance   3.13.1
     _description.text
 ;
@@ -2354,7 +2354,7 @@ save_
 save_topol_node.wyckoff_symbol
 
     _definition.id                '_topol_node.Wyckoff_symbol'
-    _definition.update            2018-02-23
+    _definition.update            2021-09-24
     _description.text
 ;
     The Wyckoff symbol (letter) as listed in the space-group section
@@ -2362,10 +2362,13 @@ save_topol_node.wyckoff_symbol
 ;
     _name.category_id             topol_node
     _name.object_id               Wyckoff_symbol
-    _type.purpose                 Encode
+    _type.purpose                 State
     _type.source                  Assigned
     _type.container               Single
-    _type.contents                Code
+    _type.contents                Text
+
+    _import.get
+        [{'file':templ_enum.cif  'save':Wyckoff_letter}]
 
 save_
 
@@ -2864,7 +2867,7 @@ save_
        _topol_link.site_symmetry_translation_2, and
        _topol_node.coordination_sequence (B. Hanson and V. Blatov)
 ;
-         0.9.4                    2021-09-17
+         0.9.4                    2021-09-24
 ;
        Added TOPOL_ATOM subcategory, _topol_link.node_id_1,
        _topol_link.node_id_2, _topol_link.structural_formula_InChI,
@@ -2934,6 +2937,9 @@ save_
        Added enumeration range of 1: to the _topol_tiling.D_size data item.
        Redefined the _topol_net.period data item as an enumeration set.
        (A. Vaitkus)
+
+       Restricted the _topol_node.Wyckoff_symbol data item values
+       to a set of case-sensitive enumeration values. (A. Vaitkus)
 
        TODO: adjust _category_key.name to allow for optional id in all
        TOPOL_* categories with _topol_*.id, as in CHEMICAL_CONN_BOND


### PR DESCRIPTION
This PR resolves issue #46 by importing an enumeration set from the `templ_enum.cif` file into the definition of the `_topol_node.Wyckoff_symbol` data item. Note, that the `_type.contents` was also changed from `Code` to `Text` to make the values case sensitive and match the definitions of similar data items from the `CIF_CORE` dictionary (`_atom_site.Wyckoff_symbol`, `space_group_Wyckoff.letter`).