### PR TITLE
Homogenise several more data item names in the dictionary examples

### DIFF
--- a/Topology.dic
+++ b/Topology.dic
@@ -10,7 +10,7 @@ data_TOPOLOGY_CIF
     _dictionary.title             TOPOLOGY_CIF
     _dictionary.class             Instance
     _dictionary.version           0.9.4
-    _dictionary.date              2021-09-24
+    _dictionary.date              2021-09-27
     _dictionary.ddl_conformance   3.13.1
     _description.text
 ;
@@ -41,7 +41,7 @@ save_TOPOL
     _definition.id                TOPOL
     _definition.scope             Category
     _definition.class             Set
-    _definition.update            2021-09-24
+    _definition.update            2021-09-27
     _description.text
 ;
     The TOPOL category covers data on connectivity
@@ -321,8 +321,8 @@ save_TOPOL
 ;
 ;
          loop_
-         _symmetry_equiv_pos_site_id
-         _symmetry_equiv_pos_as_xyz
+         _space_group_symop.id
+         _space_group_symop.operation_xyz
          1 x,y,z
          # Symmetry operations skipped
          5 z,x,y
@@ -510,8 +510,8 @@ save_TOPOL
          1 'Occurrence data are taken from topcryst.com' dia-a-a 5
 
          loop_
-         _citation_id
-         _citation_database_id_CSD
+         _citation.id
+         _citation.database_id_CSD
          1 MUMYIC
          2 MUNDAA
          3 MUMYUO
@@ -2867,7 +2867,7 @@ save_
        _topol_link.site_symmetry_translation_2, and
        _topol_node.coordination_sequence (B. Hanson and V. Blatov)
 ;
-         0.9.4                    2021-09-24
+         0.9.4                    2021-09-27
 ;
        Added TOPOL_ATOM subcategory, _topol_link.node_id_1,
        _topol_link.node_id_2, _topol_link.structural_formula_InChI,


### PR DESCRIPTION
This PR replaces several data names from the `CIF_CORE` dictionary with their main dotted forms for consistency.