### PR TITLE
Add 'none' as the measurement units to of multiple data items

### DIFF
--- a/Topology.dic
+++ b/Topology.dic
@@ -10,7 +10,7 @@ data_TOPOLOGY_CIF
     _dictionary.title             TOPOLOGY_CIF
     _dictionary.class             Instance
     _dictionary.version           0.9.4
-    _dictionary.date              2021-09-24
+    _dictionary.date              2021-10-08
     _dictionary.ddl_conformance   3.13.1
     _description.text
 ;
@@ -619,7 +619,7 @@ save_
 save_topol_atom.id
 
     _definition.id                '_topol_atom.id'
-    _definition.update            2021-08-29
+    _definition.update            2021-10-08
     _description.text
 ;
     The unique identifier of a topological "atom" that
@@ -632,13 +632,14 @@ save_topol_atom.id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
 save_topol_atom.link_id
 
     _definition.id                '_topol_atom.link_id'
-    _definition.update            2021-08-29
+    _definition.update            2021-10-08
     _description.text
 ;
     The link associated with this atom, if applicable.
@@ -656,13 +657,14 @@ save_topol_atom.link_id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
 save_topol_atom.node_id
 
     _definition.id                '_topol_atom.node_id'
-    _definition.update            2021-08-29
+    _definition.update            2021-10-08
     _description.text
 ;
     The node associated with this atom, if applicable.
@@ -676,6 +678,7 @@ save_topol_atom.node_id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -706,7 +709,7 @@ save_
 save_topol_atom.translation
 
     _definition.id                '_topol_atom.translation'
-    _definition.update            2021-09-14
+    _definition.update            2021-10-08
     _description.text
 ;
     The lattice translation vector that must be added to the
@@ -731,13 +734,14 @@ save_topol_atom.translation
     _type.container               Matrix
     _type.dimension               '[3]'
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_atom.translation_x
 
     _definition.id                '_topol_atom.translation_x'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
      The x component of the vector of lattice translations that is added
@@ -751,13 +755,14 @@ save_topol_atom.translation_x
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_atom.translation_y
 
     _definition.id                '_topol_atom.translation_y'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
     The y component of the vector of lattice translations that is added
@@ -771,13 +776,14 @@ save_topol_atom.translation_y
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_atom.translation_z
 
     _definition.id                '_topol_atom.translation_z'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
     The z component of the vector of lattice translations that is added
@@ -791,6 +797,7 @@ save_topol_atom.translation_z
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
@@ -973,7 +980,7 @@ save_
 save_topol_link.id
 
     _definition.id                '_topol_link.id'
-    _definition.update            2021-09-12
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the link.
@@ -985,6 +992,7 @@ save_topol_link.id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -1008,7 +1016,7 @@ save_
 save_topol_link.multiplicity
 
     _definition.id                '_topol_link.multiplicity'
-    _definition.update            2018-01-30
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of these links in the unit cell.
@@ -1020,13 +1028,14 @@ save_topol_link.multiplicity
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
 save_topol_link.net_id
 
     _definition.id                '_topol_link.net_id'
-    _definition.update            2021-09-11
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the net, to which this node belongs.
@@ -1039,13 +1048,14 @@ save_topol_link.net_id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
 save_topol_link.node_id_1
 
     _definition.id                '_topol_link.node_id_1'
-    _definition.update            2021-08-29
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the first node associated with a link
@@ -1061,13 +1071,14 @@ save_topol_link.node_id_1
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
 save_topol_link.node_id_2
 
     _definition.id                '_topol_link.node_id_2'
-    _definition.update            2021-08-29
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the second node associated with a link
@@ -1083,13 +1094,14 @@ save_topol_link.node_id_2
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
 save_topol_link.order
 
     _definition.id                '_topol_link.order'
-    _definition.update            2018-05-16
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of electron pairs participating in the bond
@@ -1101,6 +1113,7 @@ save_topol_link.order
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Real
+    _units.code                   none
 
 save_
 
@@ -1218,7 +1231,7 @@ save_
 save_topol_link.translation_1
 
     _definition.id                '_topol_link.translation_1'
-    _definition.update            2021-09-14
+    _definition.update            2021-10-08
     _description.text
 ;
     The lattice translation vector that must be added to the
@@ -1241,13 +1254,14 @@ save_topol_link.translation_1
     _type.container               Matrix
     _type.dimension               '[3]'
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_link.translation_1_x
 
     _definition.id                '_topol_link.translation_1_x'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
      The x component of the vector of lattice translations that is added
@@ -1261,13 +1275,14 @@ save_topol_link.translation_1_x
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_link.translation_1_y
 
     _definition.id                '_topol_link.translation_1_y'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
      The y component of the vector of lattice translations that is added
@@ -1281,13 +1296,14 @@ save_topol_link.translation_1_y
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_link.translation_1_z
 
     _definition.id                '_topol_link.translation_1_z'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
      The z component of the vector of lattice translations that is added
@@ -1301,13 +1317,14 @@ save_topol_link.translation_1_z
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_link.translation_2
 
     _definition.id                '_topol_link.translation_2'
-    _definition.update            2021-09-14
+    _definition.update            2021-10-08
     _description.text
 ;
     The lattice translation vector that must be added to the
@@ -1330,13 +1347,14 @@ save_topol_link.translation_2
     _type.container               Matrix
     _type.dimension               '[3]'
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_link.translation_2_x
 
     _definition.id                '_topol_link.translation_2_x'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
      The x component of the vector of lattice translations that is added
@@ -1350,13 +1368,14 @@ save_topol_link.translation_2_x
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_link.translation_2_y
 
     _definition.id                '_topol_link.translation_2_y'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
      The y component of the vector of lattice translations that is added
@@ -1370,13 +1389,14 @@ save_topol_link.translation_2_y
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_link.translation_2_z
 
     _definition.id                '_topol_link.translation_2_z'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
      The z component of the vector of lattice translations that is added
@@ -1390,6 +1410,7 @@ save_topol_link.translation_2_z
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
@@ -1473,7 +1494,7 @@ save_
 save_topol_net.genus
 
     _definition.id                '_topol_net.genus'
-    _definition.update            2021-09-15
+    _definition.update            2021-10-08
     _description.text
 ;
     The genus of the underlying net, defined as the cyclomatic number of
@@ -1493,13 +1514,14 @@ save_topol_net.genus
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_net.id
 
     _definition.id                '_topol_net.id'
-    _definition.update            2021-09-05
+    _definition.update            2021-10-08
     _description.text
 ;
     The unique integer identifier for this net, generally
@@ -1512,6 +1534,7 @@ save_topol_net.id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -1535,7 +1558,7 @@ save_
 save_topol_net.occurrence_total
 
     _definition.id                '_topol_net.occurrence_total'
-    _definition.update            2018-02-13
+    _definition.update            2021-10-08
     _description.text
 ;
     The total number of occurrences in literature and databases of the
@@ -1547,6 +1570,7 @@ save_topol_net.occurrence_total
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
@@ -1732,7 +1756,7 @@ save_
 save_topol_net.td10
 
     _definition.id                '_topol_net.td10'
-    _definition.update            2021-09-24
+    _definition.update            2021-10-08
     _description.text
 ;
     The topological density TD10 of the underlying net. This is the cumulative
@@ -1746,6 +1770,7 @@ save_topol_net.td10
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
@@ -1777,7 +1802,7 @@ save_
 save_topol_net.z_number
 
     _definition.id                '_topol_net.z_number'
-    _definition.update            2021-09-24
+    _definition.update            2021-10-08
     _description.text
 ;
     For 3-periodic nets, the number of symmetry-equivalent nets of this kind
@@ -1790,6 +1815,7 @@ save_topol_net.z_number
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -1905,7 +1931,7 @@ save_
 save_topol_node.coordination_sequence
 
     _definition.id                '_topol_node.coordination_sequence'
-    _definition.update            2021-09-14
+    _definition.update            2021-10-08
     _description.text
 ;
     The coordination sequence is a sequence of numbers counting the
@@ -1922,6 +1948,7 @@ save_topol_node.coordination_sequence
     _type.source                  Derived
     _type.container               List
     _type.contents                Integer
+    _units.code                   none
     _description_example.case     [4  12  24  42  64  92  124  162  204  252]
     _description_example.detail   'The diamond coordination sequence'
 
@@ -2048,7 +2075,7 @@ save_
 save_topol_node.id
 
     _definition.id                '_topol_node.id'
-    _definition.update            2021-08-29
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the node.
@@ -2060,6 +2087,7 @@ save_topol_node.id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -2083,7 +2111,7 @@ save_
 save_topol_node.net_id
 
     _definition.id                '_topol_node.net_id'
-    _definition.update            2021-09-10
+    _definition.update            2021-10-08
     _description.text
 ;
     The unique identifier of the net to which this node belongs.
@@ -2096,6 +2124,7 @@ save_topol_node.net_id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -2174,7 +2203,7 @@ save_
 save_topol_node.symmetry_multiplicity
 
     _definition.id                '_topol_node.symmetry_multiplicity'
-    _definition.update            2018-02-23
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of different sites that are generated by the
@@ -2190,6 +2219,7 @@ save_topol_node.symmetry_multiplicity
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:192
+    _units.code                   none
 
 save_
 
@@ -2222,7 +2252,7 @@ save_
 save_topol_node.translation
 
     _definition.id                '_topol_node.translation'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
     In the case where _topol_node.atom_label is given
@@ -2248,13 +2278,14 @@ save_topol_node.translation
     _type.container               Matrix
     _type.dimension               '[3]'
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_node.translation_x
 
     _definition.id                '_topol_node.translation_x'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
     In the case where _topol_node.atom_label is given
@@ -2270,13 +2301,14 @@ save_topol_node.translation_x
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_node.translation_y
 
     _definition.id                '_topol_node.translation_y'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
     In the case where _topol_node.atom_label is given
@@ -2292,13 +2324,14 @@ save_topol_node.translation_y
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_node.translation_z
 
     _definition.id                '_topol_node.translation_z'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
     In the case where _topol_node.atom_label is given
@@ -2314,6 +2347,7 @@ save_topol_node.translation_z
     _type.source                  Derived
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
@@ -2431,7 +2465,7 @@ save_
 save_topol_occurrence.net_id
 
     _definition.id                '_topol_occurrence.net_id'
-    _definition.update            2021-09-10
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the net for which this occurrence is described.
@@ -2444,6 +2478,7 @@ save_topol_occurrence.net_id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -2480,7 +2515,7 @@ save_
 save_topol_tiling.d_size
 
     _definition.id                '_topol_tiling.d_size'
-    _definition.update            2021-09-24
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of distinct (not symmetry-related) chambers in the
@@ -2497,6 +2532,7 @@ save_topol_tiling.d_size
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -2521,7 +2557,7 @@ save_
 save_topol_tiling.edges
 
     _definition.id                '_topol_tiling.edges'
-    _definition.update            2018-01-30
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of independent tile edges in the natural tiling.
@@ -2532,13 +2568,14 @@ save_topol_tiling.edges
     _type.source                  Recorded
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_tiling.faces
 
     _definition.id                '_topol_tiling.faces'
-    _definition.update            2018-01-30
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of independent tile faces in the natural tiling.
@@ -2549,13 +2586,14 @@ save_topol_tiling.faces
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_tiling.id
 
     _definition.id                '_topol_tiling.id'
-    _definition.update            2021-08-10
+    _definition.update            2021-10-08
     _description.text
 ;
     The unique identifier of the tiling.
@@ -2567,13 +2605,14 @@ save_topol_tiling.id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
 save_topol_tiling.net_id
 
     _definition.id                '_topol_tiling.net_id'
-    _definition.update            2021-09-10
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the net that carries this tiling.
@@ -2586,6 +2625,7 @@ save_topol_tiling.net_id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -2619,7 +2659,7 @@ save_
 save_topol_tiling.tiles
 
     _definition.id                '_topol_tiling.tiles'
-    _definition.update            2018-01-30
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of independent tiles in the natural tiling.
@@ -2630,13 +2670,14 @@ save_topol_tiling.tiles
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
 save_topol_tiling.vertices
 
     _definition.id                '_topol_tiling.vertices'
-    _definition.update            2018-01-30
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of independent tile vertices in the natural tiling.
@@ -2647,6 +2688,7 @@ save_topol_tiling.vertices
     _type.source                  Assigned
     _type.container               Single
     _type.contents                Integer
+    _units.code                   none
 
 save_
 
@@ -2700,7 +2742,7 @@ save_
 save_topol_tiling_faces.count
 
     _definition.id                '_topol_tiling_faces.count'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of faces of this size in the tile.
@@ -2712,13 +2754,14 @@ save_topol_tiling_faces.count
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            0:
+    _units.code                   none
 
 save_
 
 save_topol_tiling_faces.size
 
     _definition.id                '_topol_tiling_faces.size'
-    _definition.update            2018-02-13
+    _definition.update            2021-10-08
     _description.text
 ;
     The size of the tile face.
@@ -2730,13 +2773,14 @@ save_topol_tiling_faces.size
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            3:
+    _units.code                   none
 
 save_
 
 save_topol_tiling_faces.tile_id
 
     _definition.id                '_topol_tiling_faces.tile_id'
-    _definition.update            2018-02-13
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the tile to which this face belongs.
@@ -2750,6 +2794,7 @@ save_topol_tiling_faces.tile_id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -2776,7 +2821,7 @@ save_
 save_topol_tiling_tile.count
 
     _definition.id                '_topol_tiling_tile.count'
-    _definition.update            2021-09-13
+    _definition.update            2021-10-08
     _description.text
 ;
     The number of this kind of tile in the tiling.
@@ -2788,13 +2833,14 @@ save_topol_tiling_tile.count
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            0:
+    _units.code                   none
 
 save_
 
 save_topol_tiling_tile.id
 
     _definition.id                '_topol_tiling_tile.id'
-    _definition.update            2018-02-13
+    _definition.update            2021-10-08
     _description.text
 ;
     The unique identifier for this tile type.
@@ -2806,13 +2852,14 @@ save_topol_tiling_tile.id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
 save_topol_tiling_tile.tiling_id
 
     _definition.id                '_topol_tiling_tile.tiling_id'
-    _definition.update            2021-09-10
+    _definition.update            2021-10-08
     _description.text
 ;
     The identifier of the tiling to which this tile belongs.
@@ -2825,6 +2872,7 @@ save_topol_tiling_tile.tiling_id
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
+    _units.code                   none
 
 save_
 
@@ -2867,7 +2915,7 @@ save_
        _topol_link.site_symmetry_translation_2, and
        _topol_node.coordination_sequence (B. Hanson and V. Blatov)
 ;
-         0.9.4                    2021-09-24
+         0.9.4                    2021-10-08
 ;
        Added TOPOL_ATOM subcategory, _topol_link.node_id_1,
        _topol_link.node_id_2, _topol_link.structural_formula_InChI,
@@ -2940,6 +2988,9 @@ save_
 
        Restricted the _topol_node.Wyckoff_symbol data item values
        to a set of case-sensitive enumeration values. (A. Vaitkus)
+
+       Added the 'none' measurement units to the definitions of multiple
+       data items. (A. Vaitkus)
 
        TODO: adjust _category_key.name to allow for optional id in all
        TOPOL_* categories with _topol_*.id, as in CHEMICAL_CONN_BOND


### PR DESCRIPTION
This PR explicitly adds the 'none' units of measurements to the definitions of multiple numeric data items to satisfy formal stylistic recommendations. Please check if these assignments are correct.

Also, please ignore the validation action failures for now, these will be resolved in a separate PR.