### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,18 @@
 name: CIFSyntaxandStyleCheck
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the main branch
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+            - '.github/**'
+
   pull_request:
     branches: [ main ]
-  workflow_dispatch:   
+    paths-ignore:
+            - '.github/**'
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -39,11 +44,56 @@ jobs:
           id: ddlm_check
   layout:
     runs-on: ubuntu-latest
-    needs: ddlm
-    steps:
-        - name: checkout
-          uses: actions/checkout@v4
+    needs: syntax
 
-        - name: check_layout
-          uses: jamesrhester/cif_dic_layout_check_action@main
-          id: layout_check
+    steps:
+      - name: Get the cache
+        uses: actions/cache@v4
+        id: cache
+        with:
+                 path: ~/.julia
+                 key: ${{ runner.os }}-julia-v2
+                 
+      - name: Install Julia
+        uses: julia-actions/setup-julia@v1
+        with:
+                version: '1.6'
+
+      - name: Install Julia packages
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+               julia -e 'import Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("Lerche");Pkg.add("FilePaths");Pkg.add("ArgParse")'
+
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+                path: main
+      - name: checkout julia tools
+        uses: actions/checkout@v4
+        with:
+                repository: jamesrhester/julia_cif_tools
+                path: julia_cif_tools
+
+      - name: Checkout CIF master files
+        uses: actions/checkout@v4
+        with:
+                repository: COMCIFS/cif_core
+                path: cif_core
+      - name: Diagnostics
+        run: |
+            ls -a
+            pwd
+            which julia
+
+      - name: one_dict_layout
+        run: |
+               julia -e 'using Pkg; Pkg.status()'
+               for file in main/*.dic
+               do      
+                  echo "Checking $file"
+                  julia -O0 ./julia_cif_tools/linter.jl -i $PWD/cif_core $file cif_core/ddl.dic
+                  if [ $? != 0 ] 
+                  then 
+                    exit 1 ;
+                  fi 
+               done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CIFSyntaxandStyleCheck
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:   
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
         - name: checkout
-          uses: actions/checkout@v2
-          
+          uses: actions/checkout@v4
+
       # Check syntax of all CIF files
         - name: check_syntax
           uses: COMCIFS/cif_syntax_check_action@master
@@ -32,7 +32,7 @@ jobs:
     needs: syntax
     steps:
         - name: checkout
-          uses: actions/checkout@v2
+          uses: actions/checkout@v4
 
         - name: check_ddlm
           uses: COMCIFS/dictionary_check_action@main
@@ -42,8 +42,8 @@ jobs:
     needs: ddlm
     steps:
         - name: checkout
-          uses: actions/checkout@v2
-          
+          uses: actions/checkout@v4
+
         - name: check_layout
           uses: jamesrhester/cif_dic_layout_check_action@main
           id: layout_check

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CIFSyntaxandStyleCheck](https://github.com/COMCIFS/TopoCif/actions/workflows/main.yml/badge.svg)](https://github.com/COMCIFS/TopoCif/actions)
+
 # Topology Dictionary
 
 The topology CIF dictionary provides data names for describing some topological characteristics of different lattices and their relation to crystal structures.


### PR DESCRIPTION
This PR correctly targets GitHub actions to the `main` branches and adds the action status badge to the README.md file.

The badge will change from `no status` to the appropriate status after the first action run. 