### PR TITLE
ITG2e: after author proof corrections

### DIFF
--- a/Topology.dic
+++ b/Topology.dic
@@ -9,8 +9,8 @@ data_TOPOLOGY_CIF
 
     _dictionary.title             TOPOLOGY_CIF
     _dictionary.class             Instance
-    _dictionary.version           0.9.6
-    _dictionary.date              2024-02-13
+    _dictionary.version           0.9.7
+    _dictionary.date              2024-02-20
     _dictionary.uri
         https://raw.githubusercontent.com/COMCIFS/TopoCif/master/Topology.dic
     _dictionary.ddl_conformance   4.1.0
@@ -2038,4 +2038,18 @@ save_
 
        Changed the _type.source attribute of all SU data items to 'Related'.
        (A. Vaitkus)
+;
+         0.9.7                    2024-02-20
+;
+       Removed _topol_link.net_id and _topol_net.overall_topology in line
+       with proof corrections of draft chapters 3.9 and 4.9 by Blatov et al.
+       (B. McMahon)
+
+       Replaced example placeholders in TOPOL category by _import.get of
+       associated topo_examples.cif file.
+       (B. McMahon)
+
+       Made various small style and punctuation changes to prepare for
+       publication in International Tables Volume G.
+       (B. McMahon)
 ;

--- a/Topology.dic
+++ b/Topology.dic
@@ -1966,12 +1966,12 @@ save_
        _topol_link.symop_id_1 and _topol_link.symop_id_2 data items
        to be compatible with the data items that they are linked to.
        (A. Vaitkus)
-
-       Changed the _type.source attribute of all SU data items to 'Related'.
-       (A. Vaitkus)
 ;
          0.9.7                    2024-02-20
 ;
+       Changed the _type.source attribute of all SU data items to 'Related'.
+       (A. Vaitkus)
+
        Removed _topol_link.net_id and _topol_net.overall_topology in line
        with proof corrections of draft chapters 3.9 and 4.9 by Blatov et al.
        (B. McMahon)

--- a/Topology.dic
+++ b/Topology.dic
@@ -54,51 +54,8 @@ save_TOPOL
     _name.category_id             TOPOLOGY
     _name.object_id               TOPOL
 
-    loop_
-      _description_example.case
-      _description_example.detail
-;
-       [ex 1]
-;
-;
-         Example 1
-;
-;
-       [ex 2]
-;
-;
-         Example 2
-;
-;
-       [ex 3]
-;
-;
-         Example 3
-;
-;
-       [ex 4]
-;
-;
-         Example 4
-;
-;
-       [ex 5]
-;
-;
-         Example 5
-;
-;
-       [ex 6]
-;
-;
-         Example 6
-;
-;
-       [ex 7]
-;
-;
-         Example 7
-;
+    _import.get
+        [{'file':topo_examples.cif  'save':topol_examples}]
 
 save_
 
@@ -169,7 +126,7 @@ save_topol_atom.element_symbol
     a single element symbol found on the official IUPAC Periodic Table.
     For example: 'C', 'H', or 'Co', without isotope or charge.
     Data items in the ATOM_SITE category that do not correspond to elements
-    of the periodic table should be represented here as '.'.
+    of the Periodic Table should be represented here as '.'.
 ;
     _name.category_id             topol_atom
     _name.object_id               element_symbol
@@ -288,9 +245,9 @@ save_topol_atom.translation
     and the original position is (0.2,0.7,1.0) in fractional coordinates,
     then the resultant position is (-0.3,0.2,1.0). Alternatively,
     _topol_atom.translation_x,
-    _topol_atom.translation_y, and
+    _topol_atom.translation_y and
     _topol_atom.translation_z data items may be used to
-    describe separate components of the vector for CIF1 compatibility.
+    describe separate components of the vector for CIF 1 compatibility.
     If this item is omitted or
     assigned to '.' it is assumed to be equal to [0,0,0].
 ;
@@ -398,7 +355,7 @@ save_TOPOL_LINK
     _description.text
 ;
     The TOPOL_LINK category describes the crystal structure
-    connectivity and encodes the weighted colored
+    connectivity and encodes the weighted coloured
     symmetry-labeled quotient graph, from which the whole
     periodic net describing the overall topology of the crystal
     structure can be restored. The definition of
@@ -408,8 +365,7 @@ save_TOPOL_LINK
     connections described in TOPOL_LINK may correspond to any
     vectors in the structure, not just bonds or contacts. The two end-point
     references are to nodes listed in TOPOL_NODE using
-    _topol_link.node_id_1 and _topol_link.node_id_2.
-    In the case of multiple nets, _topol_link.net_id is required. Other
+    _topol_link.node_id_1 and _topol_link.node_id_2. Other
     items in this category are optional. If the link itself represents
     atoms (as in the case of a molecular linker), the atoms comprising the
     link must be referenced by _topol_atom.link_id.
@@ -512,26 +468,6 @@ save_topol_link.multiplicity
     _name.object_id               multiplicity
     _type.purpose                 Number
     _type.source                  Derived
-    _type.container               Single
-    _type.contents                Integer
-    _enumeration.range            1:
-    _units.code                   none
-
-save_
-
-save_topol_link.net_id
-
-    _definition.id                '_topol_link.net_id'
-    _definition.update            2021-10-08
-    _description.text
-;
-    The identifier of the net, to which this node belongs.
-;
-    _name.category_id             topol_link
-    _name.object_id               net_id
-    _name.linked_item_id          '_topol_net.id'
-    _type.purpose                 Link
-    _type.source                  Related
     _type.container               Single
     _type.contents                Integer
     _enumeration.range            1:
@@ -688,7 +624,7 @@ save_topol_link.translation_1
     and the original position is (0.2,0.7,1.0) in fractional coordinates,
     then the resultant position is (-0.3,0.2,1.0). Alternatively,
     _topol_link.translation_1_x,
-    _topol_link.translation_1_y, and
+    _topol_link.translation_1_y and
     _topol_link.translation_1_z data items may be used to
     describe separate components of the vector.
 ;
@@ -785,7 +721,7 @@ save_topol_link.translation_2
     and the original position is (0.2,0.7,1.0) in fractional coordinates,
     then the resultant position is (-0.3,0.2,1.0). Alternatively,
     _topol_link.translation_2_x,
-    _topol_link.translation_2_y, and
+    _topol_link.translation_2_y and
     _topol_link.translation_2_z data items may be used to
     describe separate components of the vector.
 ;
@@ -954,6 +890,7 @@ save_TOPOL_NET
 
     Reference: Delgado-Friedrichs, O., Foster, M. D., O'Keeffe, M.,
           Proserpio, D. M., Treacy, M. M. J. & Yaghi, O. M. (2005).
+	  What do we know about three-periodic nets?
           J. Solid State Chem. 178, 2533-2554,
           DOI:10.1016/j.jssc.2005.06.037.
 ;
@@ -977,7 +914,8 @@ save_topol_net.genus
     repeat unit and the edges are all the edges of the repeat unit.
 
     Reference: Delgado-Friedrichs, O. & O'Keeffe, M.
-    (2005). J. Solid State Chem. 178, 2480-2485,
+    (2005). Crystal nets as graphs: Terminology and definitions.
+    J. Solid State Chem. 178, 2480-2485,
     DOI:10.1016/j.jssc.2005.06.011.
 ;
     _name.category_id             topol_net
@@ -1027,24 +965,6 @@ save_topol_net.label
 
 save_
 
-save_topol_net.overall_topology
-
-    _definition.id                '_topol_net.overall_topology'
-    _definition.update            2018-01-30
-    _description.text
-;
-    The overall topology symbol in an arbitrary form.
-;
-    _name.category_id             topol_net
-    _name.object_id               overall_topology
-    _type.purpose                 Describe
-    _type.source                  Assigned
-    _type.container               Single
-    _type.contents                Text
-    _description_example.case     'face-centered cubic topology'
-
-save_
-
 save_topol_net.overall_topology_epinet
 
     _definition.id                '_topol_net.overall_topology_EPINET'
@@ -1070,7 +990,7 @@ save_topol_net.overall_topology_iza
     _definition.update            2018-01-30
     _description.text
 ;
-    The three-letters symbol for a Zeolite Framework Types that has
+    The three-letter symbol for a Zeolite Framework Types that has
     been approved by the Structure Commission of the International
     Zeolite Association (IZA-SC).
 
@@ -1097,7 +1017,9 @@ save_topol_net.overall_topology_rcsr
     by O'Keeffe et al. (2008).
 
     Reference: O'Keeffe, M., Peskov, M. A., Ramsden, S. J. & Yaghi, O. M.
-    (2008). Acc. Chem. Res. 41, 1782-1789, DOI:10.1021/ar800124u.
+    (2008). The Reticular Chemistry Structure Resource (RCSR) Database of,
+    and Symbols for, Crystal Nets. Acc. Chem. Res. 41, 1782-1789,
+    DOI:10.1021/ar800124u.
 ;
     _name.category_id             topol_net
     _name.object_id               overall_topology_RCSR
@@ -1118,8 +1040,9 @@ save_topol_net.overall_topology_sp
     The overall topology symbol according to the nomenclature of
     Fischer for sphere packings described by Koch et al. (2006).
 
-    Reference: Koch, E., Fischer, W. & Sowa, H. (2006). Acta Cryst.
-    A62, 152-167, DOI:10.1107/S010876730600362X.
+    Reference: Koch, E., Fischer, W. & Sowa, H. (2006). Interpenetration
+    of homogeneous sphere packings and of two-periodic layers of spheres.
+    Acta Cryst. A62, 152-167, DOI:10.1107/S010876730600362X.
 ;
     _name.category_id             topol_net
     _name.object_id               overall_topology_SP
@@ -1142,12 +1065,13 @@ save_topol_net.overall_topology_topos
     (coordination numbers) of all independent nodes; D is one of the letters
     C (chain), L (layer) or T (three-periodic) designating the dimensionality
     of the net; and n enumerates non-isomorphic nets with a given ND sequence.
-    For finite (molecular) graphs the symbols NMK-n are used, where k is the
+    For finite (molecular) graphs the symbols NMk-n are used, where k is the
     number of vertices (atoms) in the graph.
 
     Reference: Aman, F., Asiri, A. M., Siddiqui, W. A., Arshad, M. N.,
-    Ashraf, A., Zakharov, N. S. & Blatov, V. A. (2014). Cryst. Eng. Comm,
-    16, 1963-1970, DOI:10.1039/C3CE42218F.
+    Ashraf, A., Zakharov, N. S. & Blatov, V. A. (2014). Multilevel
+    topological description of molecular packings in 1,2-benzothiazines.
+    Cryst. Eng. Comm, 16, 1963-1970, DOI:10.1039/C3CE42218F.
 ;
     _name.category_id             topol_net
     _name.object_id               overall_topology_TOPOS
@@ -1281,11 +1205,9 @@ save_TOPOL_NODE
     _description.text
 ;
     The TOPOL_NODE category, along with TOPOL_ATOM, describes the topological
-    properties, position, and chemical composition
-    of the nodes of the underlying net. The TOPOL_NODE category is optional.
-    It is only required for polyatomic nodes or in cases where the
-    label given to the node is different from _atom_site.label. Data items
-    _topol_node.fract_x, _topol_node.fract_y, and _topol_node.fract_z must be
+    properties, position and chemical composition
+    of the nodes of the underlying net. Data items
+    _topol_node.fract_x, _topol_node.fract_y and _topol_node.fract_z must be
     present only if the node's position cannot be derived from
     other data items in TOPOL_NODE or TOPOL_ATOM.
     Fractional coordinates can be given in other
@@ -1294,6 +1216,8 @@ save_TOPOL_NODE
     In the case of multiple nets, _topol_node.net_id is also required.
 
     Reference: Blatov, V. A., O'Keeffe, M. & Proserpio, D. M. (2010).
+    Vertex-, face-, point-, Schl\"afli-, and Delaney-symbols in nets,
+    polyhedra and tilings: recommended terminology.
     Cryst. Eng. Comm. 12, 44-48, DOI:10.1039/B910671E.
 ;
     _name.category_id             TOPOLOGY
@@ -1335,7 +1259,7 @@ save_topol_node.coordination_sequence_plain
     _definition.update            2021-07-28
     _description.text
 ;
-    A CIF1-compatible alternative representation of the coordination sequence
+    A CIF 1 compatible alternative representation of the coordination sequence
     as plain text, as a quoted string of white-space-separated numbers.
 ;
     _name.category_id             topol_node
@@ -1355,7 +1279,7 @@ save_topol_node.extended_point_symbol
     _definition.update            2021-10-20
     _description.text
 ;
-    The extended point symbol of a N-coordinated node lists all shortest
+    The extended point symbol of an N-coordinated node lists all shortest
     circuits for each of the N(N-1)/2 angles (pairs of edges) incident to
     the node. It is written as A(a).B(b)... where A, B, ... designate sizes of
     circuits, which meet at angles A, B, ..., and a, b, ... designate numbers
@@ -1375,13 +1299,13 @@ save_topol_node.extended_point_symbol
       _description_example.case
       _description_example.detail
          6(2).6(2).6(2).6(2).6(2).6(2)
-             'ES for a vertex in the diamond structure'
+             'extended symbol for a vertex in the diamond structure'
          4.6(2).4.8(3).6(2).6(2)
-             'ES for one vertex of feldspar net'
+             'extended symbol for one vertex of feldspar net'
          7(2).9(2).7(3).7(3).7(3).7(3)
-             'ES for the vertex of qzd net'
+             'extended symbol for the vertex of qzd net'
          4.4.4.4.6(3).6(3).6(5).6(5).6(5).6(5)
-             'ES for the vertex of 5-c sqp net'
+             'extended symbol for the vertex of 5-c sqp net'
 
 save_
 
@@ -1639,10 +1563,13 @@ save_topol_node.vertex_symbol
     loop_
       _description_example.case
       _description_example.detail
-         6(2).6(2).6(2).6(2).6(2).6(2)      'Vertex symbol for diamond'
-         4.6(2).4.8.6.6(2)                  'VS for one vertex of feldspar net'
-         7(2).*.7(3).7(3).7(3).7(3)         'VS for the vertex of qzd net'
-         4.4.4.4.6.6.6(5).6(5).6(5).6(5)    'VS for the vertex of 5-c sqp net'
+         6(2).6(2).6(2).6(2).6(2).6(2)      'vertex symbol for diamond'
+         4.6(2).4.8.6.6(2)
+             'vertex symbol for one vertex of feldspar net'
+         7(2).*.7(3).7(3).7(3).7(3)
+             'vertex symbol for the vertex of qzd net'
+         4.4.4.4.6.6.6(5).6(5).6(5).6(5)
+             'vertex symbol for the vertex of 5-c sqp net'
 
 save_
 
@@ -1662,8 +1589,7 @@ save_topol_node.wyckoff_symbol
     _type.container               Single
     _type.contents                Text
 
-    _import.get
-        [{'file':templ_enum.cif  'save':Wyckoff_letter}]
+    _import.get   [{'file':templ_enum.cif 'save':Wyckoff_letter}]
 
 save_
 
@@ -1677,7 +1603,7 @@ save_TOPOL_TILING
 ;
     The TOPOL_TILING category describes the natural tiling
     corresponding to the underlying net.  A tiling is a
-    partition of crystal space using generalised polyhedra, and a
+    partition of crystal space using generalized polyhedra, and a
     natural tiling is one for which tiles are the smallest possible
     that conserve the full symmetry of the net and for which the
     faces are all locally strong rings. This means that there is no
@@ -1688,7 +1614,8 @@ save_TOPOL_TILING
     the number of faces of a given size in the tile.
 
     Reference: Blatov, V. A., Delgado-Friedrichs, O., O'Keeffe M. &
-    Proserpio D. M. (2007). Acta Cryst. A63, 418-425,
+    Proserpio D. M. (2007). Three-periodic nets and tilings: natural
+    tilings for nets. Acta Cryst. A63, 418-425,
     DOI:10.1107/S0108767307038287.
 ;
     _name.category_id             TOPOLOGY
@@ -1704,10 +1631,12 @@ save_topol_tiling.d_size
     _description.text
 ;
     The number of distinct (not symmetry-related) chambers in the
-    tiling as expressed by the Delaney Dress symbol or just D-symbol,
+    tiling as expressed by the Delaney-Dress symbol or just D-symbol,
     as a measure of the complexity of the tiling (D-size).
 
     Reference: Blatov, V. A., O'Keeffe, M. & Proserpio, D. M. (2010).
+    Vertex-, face-, point-, Schl\"afli-, and Delaney-symbols in nets,
+    polyhedra and tilings: recommended terminology.
     Cryst. Eng. Comm. 12, 44-48, DOI:10.1039/B910671E.
 ;
     _name.category_id             topol_tiling

--- a/Topology.dic
+++ b/Topology.dic
@@ -890,7 +890,7 @@ save_TOPOL_NET
 
     Reference: Delgado-Friedrichs, O., Foster, M. D., O'Keeffe, M.,
           Proserpio, D. M., Treacy, M. M. J. & Yaghi, O. M. (2005).
-	  What do we know about three-periodic nets?
+          What do we know about three-periodic nets?
           J. Solid State Chem. 178, 2533-2554,
           DOI:10.1016/j.jssc.2005.06.037.
 ;
@@ -1563,7 +1563,8 @@ save_topol_node.vertex_symbol
     loop_
       _description_example.case
       _description_example.detail
-         6(2).6(2).6(2).6(2).6(2).6(2)      'vertex symbol for diamond'
+         6(2).6(2).6(2).6(2).6(2).6(2)
+             'vertex symbol for diamond'
          4.6(2).4.8.6.6(2)
              'vertex symbol for one vertex of feldspar net'
          7(2).*.7(3).7(3).7(3).7(3)
@@ -1589,7 +1590,8 @@ save_topol_node.wyckoff_symbol
     _type.container               Single
     _type.contents                Text
 
-    _import.get   [{'file':templ_enum.cif 'save':Wyckoff_letter}]
+    _import.get
+        [{'file':templ_enum.cif  'save':Wyckoff_letter}]
 
 save_
 

--- a/topo_examples.cif
+++ b/topo_examples.cif
@@ -1,3 +1,7 @@
+#\#CIF_2.0
+
+data_TOPOLOGY_EXAMPLES
+
 save_topol_examples
 
 loop_

--- a/topo_examples.cif
+++ b/topo_examples.cif
@@ -1,0 +1,536 @@
+save_topol_examples
+
+loop_
+ _description_example.case
+ _description_example.detail
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+; 
+loop_
+  _space_group_symop.id
+  _space_group_symop.operation_xyz
+    1 x,y,z
+    2 1/4-x,1/4-y,z
+    # - - - - data truncated for brevity - - - -
+    13 -y,-x,-z
+    # - - - - data truncated for brevity - - - -
+    192 3/4-z,1/2+y,1/4-x
+
+loop_
+  _atom_site.label
+  _atom_site.fract_x
+  _atom_site.fract_y
+  _atom_site.fract_z
+    C1 0.12500 0.12500 0.12500
+
+loop_
+  _topol_net.id
+  _topol_net.overall_topology_RCSR
+    1 dia
+
+loop_
+  _topol_node.id
+  _topol_node.net_id
+    1 1
+
+loop_
+  _topol_link.id
+  _topol_link.node_id_1
+  _topol_link.node_id_2
+  _topol_link.symop_id_1
+  _topol_link.translation_1
+  _topol_link.symop_id_2
+  _topol_link.translation_2
+  _topol_link.distance
+  _topol_link.Voronoi_solid_angle
+  _topol_link.type
+  _topol_link.order
+  _topol_link.multiplicity
+    1 1 1 1 [0 0 0] 13 [0 0 0] 1.5446 22.04 v 1 16
+
+loop_
+  _topol_atom.id
+  _topol_atom.node_id
+  _topol_atom.atom_label
+  _topol_atom.element_symbol
+    1 1 C1 C
+; 
+
+; 
+Example 1 - Connectivity of the diamond crystal structure.
+   All atoms coincide with the nodes and all bonds coincide
+   with the edges, so the atomic network coincides with the
+   underlying net.
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+;
+loop_
+  _space_group_symop.id
+  _space_group_symop.operation_xyz
+    1 x,y,z
+    2 -x,-y,z
+    3 x,-y,-z
+    # - - - - data truncated for brevity - - - -
+    24 -z,y,-x
+
+loop_
+  _atom_site.label
+  _atom_site.fract_x
+  _atom_site.fract_y
+  _atom_site.fract_z
+    Li1 0.00000 0.00000 0.00000
+    C1  0.31850 0.31850 0.31850
+    O1  0.19920 0.19920 0.19920
+    Co1 0.50000 0.50000 0.50000
+
+loop_
+  _topol_net.id
+  _topol_net.label
+  _topol_net.z_number
+  _topol_net.special_details
+  _topol_net.overall_topology_TOPOS
+    1 Net_1 2 'Atomic network' 'Unknown'
+    2 Net_2 2 'Underlying net with carbonyl ligands as nodes' '2,4T3'
+
+loop_
+  _topol_node.id
+  _topol_node.label
+  _topol_node.net_id
+  _topol_node.fract_x
+  _topol_node.fract_y
+  _topol_node.fract_z
+    1 Li1 1  .       .       .      # Li
+    2 C1  1  .       .       .      # C
+    3 O1  1  .       .       .      # O
+    4 Co1 1  .       .       .      # Co
+    5 ZA1 2  .       .       .      # Li
+    6 ZB1 2 0.25036 0.25036 0.25036 # (CO)
+    7 ZC1 2  .       .       .      # Co
+
+loop_
+  _topol_link.id
+  _topol_link.node_id_1
+  _topol_link.node_id_2
+  _topol_link.distance
+  _topol_link.type
+    1 1 3 1.9121 v  # Li1-O1
+    2 2 3 1.1452 v  # C1-O1
+    3 2 4 1.7422 v  # C1-Co1
+    4 5 6 2.4032 gl # Li1-(CO)
+    5 6 7 2.3963 gl # (CO)-Co
+
+loop_
+  _topol_atom.id
+  _topol_atom.node_id
+  _topol_atom.atom_label
+  _topol_atom.element_symbol
+    1 1 Li1 Li
+    2 2 C1  C
+    3 3 O1  O
+    4 4 Co1 Co
+    5 5 Li1 Li
+    6 6 C1  C
+    7 6 O1  O
+    8 7 Co1 Co
+; 
+
+; Example 2 - Connectivity of atomic and underlying nets for an
+  interpenetrating array of two LiCo(CO)4 networks. The atomic net
+  consists of Li, C, O, and Co atoms, while the underlying net is built
+  from three kinds of nodes: Li and Co atoms and carbonyl (CO) ligand;
+  the nodes are labeled as ZA1, ZC1, and ZB1, respectively. Two
+  possible variants are shown: the coordinates of ZA1 are specified by
+  a reference to the Li1 atom, while the coordinates of ZC1 are specified
+  explicitly. Both atomic and underlying nets are described in the
+  TOPOL_NET section.
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+loop_
+  _space_group_symop.id
+  _space_group_symop.operation_xyz
+    1 x,y,z
+    2 -y,x-y,z
+    3 -x+y,-x,z
+    # - - - - data truncated for brevity - - - -
+    20 1/3+x-y,2/3-y,1/6-z
+    # - - - - data truncated for brevity - - - -
+    36 1/3-y,2/3-x,1/6+z
+
+loop_
+  _atom_site.label
+  _atom_site.fract_x
+  _atom_site.fract_y
+  _atom_site.fract_z
+    C1  0.00000 0.00000 0.25000
+    O1  0.25930 0.00000 0.25000
+    Ca1 0.00000 0.00000 0.00000
+
+loop_
+  _topol_net.id
+  _topol_net.overall_topology_RCSR
+    1 pcu-b
+
+loop_
+  _topol_node.id
+  _topol_node.label
+    1 ZA1 # CO3
+    2 ZB1 # Ca
+
+loop_
+  _topol_link.id
+  _topol_link.node_id_1
+  _topol_link.node_id_2
+  _topol_link.symop_id_2
+  _topol_link.translation_2
+  _topol_link.distance
+  _topol_link.type
+    1 1 2 20 [-1 -1 0] 3.2122 gl # (CO3)-Ca
+
+loop_
+  _topol_atom.id
+  _topol_atom.node_id
+  _topol_atom.atom_label
+  _topol_atom.element_symbol
+  _topol_atom.symop_id
+    1 1 C1 C 1 
+    2 1 O1 O 1 
+    3 1 O1 O 2
+    4 1 O1 O 3
+    5 2 Ca1 Ca 1
+; 
+
+;  Example 3 - Connectivity of an underlying net of the calcite
+   (CaCO3) crystal structure. The nodes of the underlying
+   net correspond to Ca atoms and carbonate (CO3) groups.
+; 
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+; 
+loop_
+  _space_group_symop.id
+  _space_group_symop.operation_xyz
+    1 x,y,z
+    2 1/2-x,1/2-y,z
+    # - - - - data truncated for brevity - - - -
+    13 -y,-x,-z
+    # - - - - data truncated for brevity - - - -
+    48 1/2-z,y,1/2-x
+
+loop_
+  _atom_site.label
+  _atom_site.fract_x
+  _atom_site.fract_y
+  _atom_site.fract_z
+    O1  0.25000 0.25000 0.25000
+    Cu1 0.00000 0.00000 0.00000
+
+loop_
+  _topol_net.id
+  _topol_net.z_number
+  _topol_net.overall_topology_RCSR
+    1 2 'dia'
+
+loop_
+  _topol_node.id
+  _topol_node.net_id
+    1 1
+
+loop_
+  _topol_link.id
+  _topol_link.node_id_1
+  _topol_link.node_id_2
+  _topol_link.symop_id_2
+  _topol_link.type
+    1 1 1 13 gl
+
+loop_
+  _topol_atom.id
+  _topol_atom.node_id
+  _topol_atom.link_id
+  _topol_atom.atom_label
+  _topol_atom.element_symbol
+    1 1 . O1  O
+    2 . 1 Cu1 Cu
+;
+
+; Example 4 - Connectivity of an underlying net of the cuprite (Cu2O)
+  crystal structure. Oxygen atoms coincide with the nodes,
+  while copper atoms represent the edges. There are two
+  interpenetrating networks of the diamond topology.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+;
+loop_
+  _space_group_symop.id
+  _space_group_symop.operation_xyz
+    1 x,y,z
+    # - - - - data truncated for brevity - - - -
+    5 z,x,y
+    # - - - - data truncated for brevity - - - -
+    26 x,y,-z
+    # - - - - data truncated for brevity - - - -
+    37 y,x,z
+    # - - - - data truncated for brevity - - - -
+    192 1/2-z,1/2+y,-x
+
+loop_
+  _atom_site.label
+  _atom_site.fract_x
+  _atom_site.fract_y
+  _atom_site.fract_z
+    H1  0.30590 0.19410 0.04520
+    C1  0.25000 0.25000 0.11050
+    C2  0.28310 0.21690 0.02630
+    C3  0.25000 0.25000 0.05380
+    O1  .25000 0.25000 0.25000
+    O2  0.28180 0.21820 0.13390
+    Zn1 0.29350 0.20650 0.20650
+
+loop_
+  _topol_net.id
+  _topol_net.label
+  _topol_net.special_details
+  _topol_net.overall_topology_TOPOS
+    1 Net_1 'Atomic network' 'Unknown'
+    2 Net_2 'Underlying net with zinc tetranuclear complex groups as nodes and benzene rings as links (cluster representation)' 'pcu'
+    3 Net_3 'Underlying net with zinc, oxygen and benzenedicarboxylato ligands as 4-coordinate nodes (standard representation)' 'fff'
+
+loop_
+  _topol_node.id
+  _topol_node.net_id
+    1  1  # H1
+    2  1  # C1
+    3  1  # C2
+    4  1  # C3
+    5  1  # O1
+    6  1  # O2
+    7  1  # Zn1
+    8  2  # C6O13Zn4
+    9  3  # C8H4O4
+    10 3  # O1
+    11 3  # Zn1
+
+loop_
+  _topol_link.id
+  _topol_link.node_id_1
+  _topol_link.node_id_2
+  _topol_link.symop_id_2
+  _topol_link.distance
+  _topol_link.type
+    1   1  3  .   0.9594 v  # H1-C2
+    2   2  6  37  1.3013 v  # C1-O2
+    3   2  4  .   1.4554 ar # C1-C3
+    4   3  3  26  1.3502 ar # C2-C2
+    5   3  4  .   1.3936 ar # C2-C3
+    6   5  7  .   1.9340 v  # O1-Zn1
+    7   6  7  .   1.9114 v  # O2-Zn1
+    8   8  8  26 12.8345 gl # (C6O13Zn4)-(C6H4)-(C6O13Zn4)
+    9   9 11  5   5.5309 gl # (C8H4O4)-Zn1
+    10 10 11  .   1.9341 v  # O1-Zn1
+
+loop_
+  _topol_atom.id
+  _topol_atom.atom_label
+  _topol_atom.node_id
+  _topol_atom.link_id
+  _topol_atom.symop_id
+  _topol_atom.element_symbol
+    1   H1   1   .   1 H
+    2   C1   2   .   1 C
+    3   C2   3   .   1 C
+    4   C3   4   .   1 C
+    5   O1   5   .   1 O
+    6   O2   6   .   1 O
+    7   Zn1  7   .   1 Zn
+    10  C1   8   .   1 C
+    11  C1   8   .  55 C
+    12  O2   8   .  55 O
+    13  O2   8   .  80 O
+    14  O2   8   .   6 O
+    15  O2   8   .  59 O
+    16  O2   8   .  42 O
+    17  O2   8   .  78 O
+    18  C1   8   .  78 C
+    19  C1   8   .   5 C
+    20  Zn1  8   .   6 Zn
+    21  Zn1  8   .  55 Zn
+    22  C1   8   .  69 C
+    23  C1   8   .   6 C
+    24  O2   8   .  41 O
+    25  O2   8   .  69 O
+    26  O1   8   .   1 O
+    27  O2   8   .   5 O
+    28  O2   8   .  82 O
+    29  Zn1  8   .   5 Zn
+    30  Zn1  8   .   1 Zn
+    31  O2   8   .   1 O
+    32  O2   8   .  37 O
+    33  O2   9   .  14 O
+    34  O2   9   .  26 O
+    35  O2   9   .   1 O
+    36  O2   9   .  37 O
+    37  C1   9   .  14 C
+    38  C3   9   8  14 C
+    39  C2   9   8  14 C
+    40  H1   9   8  14 H
+    41  C2   9   8  37 C
+    42  H1   9   8  37 H
+    43  C2   9   8  26 C
+    44  H1   9   8  26 H
+    45  C2   9   8   1 C
+    46  H1   9   8   1 H
+    47  C3   9   8   1 C
+    48  C1   9   .   1 C
+    49  O1  10   .   1 O
+    50  Zn1 11   .   1 Zn
+; 
+#
+; Example 5 - MOF-5 (multiple nets; two polyatomic nodes and a molecular
+     linker).
+; 
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+; 
+loop_
+  _space_group_symop.id
+  _space_group_symop.operation_xyz
+    1 x,y,z
+    2 1/2-x,-y,1/2+z
+    3 1/2+x,1/2-y,-z
+    4 -x,1/2+y,1/2-z
+    5 -x,-y,-z
+    6 1/2+x,y,1/2-z
+    7 1/2-x,1/2+y,z
+    8 x,1/2-y,1/2+z
+
+loop_
+  _atom_site.label
+  _atom_site.fract_x
+  _atom_site.fract_y
+  _atom_site.fract_z
+    H1 0.19700 0.11100 0.02200
+    H2 0.05900 0.26600 0.08700
+    C1 0.14120 0.08370 0.23120
+    N1 0.14590 0.16990 0.10179
+    N2 0.14010 0.01250 0.34609
+
+loop_
+  _topol_node.id
+    1 2 3 4 5
+
+loop_
+  _topol_link.id
+  _topol_link.node_id_1
+  _topol_link.node_id_2
+  _topol_link.distance
+  _topol_link.symop_id_2
+  _topol_link.translation_2_x
+  _topol_link.translation_2_y
+  _topol_link.translation_2_z
+  _topol_link.type
+  _topol_link.order
+    1 1 4 0.8988 1 0 0  0 v  1 # H1-N1
+    2 1 5 2.1228 2 0 0 -1 hb ? # H1-N2
+    3 2 4 0.8826 1 0 0  0 v  1 # H2-N1
+    4 2 5 2.2152 4 0 0  0 hb ? # H2-N2
+    5 3 5 1.1520 1 0 0  0 v  3 # C1-N2
+    6 3 4 1.3148 1 0 0  0 v  1 # C1-N1
+
+loop_
+  _topol_atom.id
+  _topol_atom.atom_label
+  _topol_atom.node_id
+  _topol_atom.element_symbol
+    1 H1 1 H
+    2 H2 2 H
+    3 C1 3 C
+    4 N1 4 N
+    5 N2 5 N
+; 
+
+; Example 6 - Cyanamide (simple atomic network example with hydrogen bonding).
+; 
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+;
+loop_
+  _space_group_symop.id
+  _space_group_symop.operation_xyz
+    1 x,y,z
+    2 1/4-x,1/4-y,z
+    # - - - - data truncated for brevity - - - -
+    13 -y,-x,-z
+    # - - - - data truncated for brevity - - - -
+    41 x,z,y
+    42 z,y,x
+    # - - - - data truncated for brevity - - - -
+    47 x,1/4-z,1/4-y
+    # - - - - data truncated for brevity - - - -
+    192 3/4-z,1/2+y,1/4-x
+
+loop_
+  _atom_site.label
+  _atom_site.fract_x
+  _atom_site.fract_y
+  _atom_site.fract_z
+    Si1 0.94690 0.12510 0.03640
+
+loop_
+  _topol_net.id
+  _topol_net.overall_topology_IZA
+    1 FAU
+
+loop_
+  _topol_node.id
+  _topol_node.net_id
+  _topol_node.label
+    1 1 Si
+
+loop_
+  _topol_link.id
+  _topol_link.node_id_1
+  _topol_link.node_id_2
+  _topol_link.distance
+  _topol_link.symop_id_2
+  _topol_link.translation_2
+  _topol_link.type
+    1 1 1 3.0470 47 [0 0 0] gl
+    2 1 1 3.0473 13 [1 1 0] gl
+    3 1 1 3.0539 41 [0 0 0] gl
+    4 1 1 3.0814 42 [1 0 -1] gl
+
+loop_
+  _topol_atom.id
+  _topol_atom.node_id
+  _topol_atom.atom_label
+  _topol_atom.element_symbol
+    1 1 Si1 Si
+
+loop_
+  _topol_tiling.id
+  _topol_tiling.net_id
+  _topol_tiling.signature
+  _topol_tiling.vertices
+  _topol_tiling.edges
+  _topol_tiling.faces
+  _topol_tiling.tiles
+  _topol_tiling.d_size
+    1 1 '2[4^6.6^2]+[4^6.6^8]+[4^18.6^4.12^4]' 1 4 5 3 24
+;
+
+; Example 7 - FAU zeolite tiling example.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+save_
+
+


### PR DESCRIPTION
Suggested update to dictionary after receiving author proof corrections for International Tables G 2nd edition.

(1) Examples in category TOPOL imported from new topo_examples.cif file.

(2) Numerous small style changes (spelling, punctuation, addition of titles to references). These should be uncontroversial.

(3) Removal of _topol_link.net_id and _topol_net.overall_topology - these may need double-checking with authors.