### PR TITLE
Add SPDX identifier to the dictionary file

### DIFF
--- a/cif_topo.dic
+++ b/cif_topo.dic
@@ -1,4 +1,5 @@
 #\#CIF_2.0
+# SPDX-License-Identifier: CC-BY-4.0
 ################################################################################
 #                                                                              #
 #       Topology CIF dictionary                                                #


### PR DESCRIPTION
This PR adds the CC-BY-4.0 SPDX identifiers to dictionary files as discussed in issue https://github.com/COMCIFS/cif_core/issues/247.